### PR TITLE
update to exosphere 371a188ab

### DIFF
--- a/.github/actions/create-instance/action.yml
+++ b/.github/actions/create-instance/action.yml
@@ -244,13 +244,11 @@ runs:
         fi
         sed -i "s|{runner-ssh-public-key}|$(cat "$RUNNER_PUBKEY")|g" ./cloud-config
 
-        # Update INSTANCE_FAVOR placeholder to ensure current value is passed to ansible
-        sed -i 's/INSTANCE_FLAVOR/$INSTANCE_FLAVOR/g' ./cloud-config
 
         openstack server create "$INSTANCE_NAME" \
           --nic net-id="auto_allocated_network" \
           --security-group "exosphere" \
-          --flavor $INSTANCE_FLAVOR \
+          --flavor "$INSTANCE_FLAVOR" \
           --image "Featured-Ubuntu24" \
           --key-name "murat-key" \
           --property "exoGuac={\"v\":1,\"ssh\":true,\"vnc\":true}" \

--- a/cloud-config
+++ b/cloud-config
@@ -85,7 +85,7 @@ exosphere_sha="371a188abf480ede688466fbe4a03e34d9a7f784" # morpho-cloud-portal-2
 
 ansible-playbook \
   -i /opt/instance-config-mgt/ansible/hosts \
-  -e "{\"guac_enabled\":true,\"gui_enabled\":true,\"ansible_python_interpreter\":\"/opt/ansible-venv/bin/python\",\"instance_flavor\":\"INSTANCE_FLAVOR\"}" \
+  -e "{\"guac_enabled\":true,\"gui_enabled\":true,\"ansible_python_interpreter\":\"/opt/ansible-venv/bin/python\"}" \
   /opt/instance-config-mgt/ansible/playbook.yml
 ANSIBLE_RETURN_CODE=$?
 if [ $ANSIBLE_RETURN_CODE -eq 0 ]; then STATUS="complete"; else STATUS="error"; fi

--- a/cloud-config
+++ b/cloud-config
@@ -80,7 +80,7 @@ retry git clone \
   "https://github.com/MorphoCloud/exosphere.git" \
   /opt/instance-config-mgt
 
-exosphere_sha="e5d42805cd28fbd9de2df61c09a0b62cfb01bba0" # morpho-cloud-portal-2026.06-ubuntu24-prep
+exosphere_sha="371a188abf480ede688466fbe4a03e34d9a7f784" # morpho-cloud-portal-2026.06-ubuntu24-prep
 (cd /opt/instance-config-mgt && git reset --hard $exosphere_sha)
 
 ansible-playbook \


### PR DESCRIPTION
Removes the obsolete g3.xl NVIDIA driver workaround end-to-end: bumps the exosphere pin to 371a188ab (task deleted there — JS2 provisions passthrough GPU flavors with a generic non-GRID driver natively), removes the never-substituted `instance_flavor` plumbing (broken single-quoted sed + ansible extra-var) from the create path, and quotes `--flavor`. Everything removed was provably never executed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)