### PR TITLE
SHA-pin all third-party actions; gate on-admin-mention to members

### DIFF
--- a/.github/actions/comment-progress/action.yml
+++ b/.github/actions/comment-progress/action.yml
@@ -54,7 +54,7 @@ runs:
 
     - name: Render template
       id: template
-      uses: chuhlomin/render-template@v1
+      uses: chuhlomin/render-template@a7c644e341797d050d1cb24332d83791b9a46dae # v1
       with:
         template: .github/instance-creation-progress-template.md
         vars: |
@@ -81,7 +81,7 @@ runs:
 
     - name: comment (progress)
       id: couc
-      uses: peter-evans/create-or-update-comment@v4.0.0
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       with:
         comment-id: ${{ inputs.comment-id }}
         issue-number: ${{ inputs.issue-number }}

--- a/.github/actions/control-instance/action.yml
+++ b/.github/actions/control-instance/action.yml
@@ -106,7 +106,7 @@ runs:
 
     - name: command results comment (Instance management not approved)
       if: ${{ ! fromJSON(steps.check_approval.outputs.is_approved) }}
-      uses: peter-evans/create-or-update-comment@v4.0.0
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       with:
         issue-number: ${{ inputs.issue_number }}
         body: |
@@ -132,7 +132,7 @@ runs:
 
     - name: command results comment (Instance does not exist)
       if: ${{ steps.check_instance.outputs.exists == 'false' }}
-      uses: peter-evans/create-or-update-comment@v4.0.0
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       with:
         issue-number: ${{ inputs.issue_number }}
         body: |
@@ -162,7 +162,7 @@ runs:
 
     - name: comment (server action already in progress)
       if: ${{ steps.check_task_state.outcome == 'failure' && failure() }}
-      uses: peter-evans/create-or-update-comment@v4.0.0
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       with:
         issue-number: ${{ inputs.issue_number }}
         body: |
@@ -251,7 +251,7 @@ runs:
 
     - name: comment (failed to check instance IP)
       if: ${{ steps.check_instance_has_ip.outcome == 'failure' && failure() }}
-      uses: peter-evans/create-or-update-comment@v4.0.0
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       with:
         issue-number: ${{ inputs.issue_number }}
         body: |
@@ -316,7 +316,7 @@ runs:
 
     - name: comment (failed to retrieve or create floating IP)
       if: ${{ steps.ip_create.outcome == 'failure' && failure() }}
-      uses: peter-evans/create-or-update-comment@v4.0.0
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       with:
         issue-number: ${{ inputs.issue_number }}
         body: |
@@ -380,7 +380,7 @@ runs:
 
     - name: comment (failed to associate floating IP with unshelved instance)
       if: ${{ steps.associate_ip.outcome == 'failure' && failure() }}
-      uses: peter-evans/create-or-update-comment@v4.0.0
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       with:
         issue-number: ${{ inputs.issue_number }}
         body: |
@@ -406,7 +406,7 @@ runs:
 
     - name: command results comment (failure)
       if: ${{ steps.execute_command.outcome == 'failure' && failure() }}
-      uses: peter-evans/create-or-update-comment@v4.0.0
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       with:
         issue-number: ${{ inputs.issue_number }}
         body: |
@@ -489,7 +489,7 @@ runs:
       if:
         ${{ steps.instance_poll.outcome == 'failure' && failure() &&
         steps.instance_poll.outputs.capacity_error != 'true' }}
-      uses: peter-evans/create-or-update-comment@v4.0.0
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       with:
         issue-number: ${{ inputs.issue_number }}
         body: |
@@ -528,7 +528,7 @@ runs:
 
     - name: comment (no capacity available)
       if: ${{ steps.instance_poll.outputs.capacity_error == 'true' }}
-      uses: peter-evans/create-or-update-comment@v4.0.0
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       with:
         issue-number: ${{ inputs.issue_number }}
         body: |
@@ -580,7 +580,7 @@ runs:
 
     - name: comment (failed to disassociate floating IP from unshelved instance)
       if: ${{ steps.disassociate_ip.outcome == 'failure' && failure() }}
-      uses: peter-evans/create-or-update-comment@v4.0.0
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       with:
         issue-number: ${{ inputs.issue_number }}
         body: |
@@ -613,7 +613,7 @@ runs:
 
     - name: comment (failed to set instance properties)
       if: ${{ steps.set_instance_properties.outcome == 'failure' && failure() }}
-      uses: peter-evans/create-or-update-comment@v4.0.0
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       with:
         issue-number: ${{ inputs.issue_number }}
         body: |
@@ -662,7 +662,7 @@ runs:
       if:
         ${{ (steps.send_email_individual.outcome == 'failure' ||
         steps.send_email_course.outcome == 'failure') && failure() }}
-      uses: peter-evans/create-or-update-comment@v4.0.0
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       with:
         issue-number: ${{ inputs.issue_number }}
         body: |
@@ -674,7 +674,7 @@ runs:
 
     - name: command results comment (success)
       if: ${{ steps.check_instance.outputs.exists == 'true' && success() }}
-      uses: peter-evans/create-or-update-comment@v4.0.0
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       with:
         issue-number: ${{ inputs.issue_number }}
         body: |

--- a/.github/actions/create-instance/action.yml
+++ b/.github/actions/create-instance/action.yml
@@ -101,7 +101,7 @@ runs:
 
     - name: comment (Instance already created)
       if: ${{ fromJSON(steps.check_instance.outputs.exists) }}
-      uses: peter-evans/create-or-update-comment@v5.0.0
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       with:
         issue-number: ${{ inputs.issue_number }}
         body: |
@@ -128,7 +128,7 @@ runs:
 
     - name: comment (floating IP creation failed)
       if: ${{ steps.ip_create.outcome == 'failure' && failure() }}
-      uses: peter-evans/create-or-update-comment@v5.0.0
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       with:
         issue-number: ${{ inputs.issue_number }}
         body: |
@@ -166,7 +166,7 @@ runs:
 
     - name: comment (volume already exists)
       if: ${{ fromJSON(steps.check_volume.outputs.exists) }}
-      uses: peter-evans/create-or-update-comment@v5.0.0
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       with:
         issue-number: ${{ inputs.issue_number }}
         body: |
@@ -189,7 +189,7 @@ runs:
 
     - name: comment (failed to create volume)
       if: ${{ steps.create_volume.outcome == 'failure' && failure() }}
-      uses: peter-evans/create-or-update-comment@v5.0.0
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       with:
         issue-number: ${{ inputs.issue_number }}
         body: |
@@ -339,7 +339,7 @@ runs:
 
     - name: comment (no capacity available)
       if: ${{ steps.check_capacity_error.outputs.capacity_error == 'true' }}
-      uses: peter-evans/create-or-update-comment@v5.0.0
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       with:
         issue-number: ${{ inputs.issue_number }}
         body: |
@@ -400,7 +400,7 @@ runs:
         steps.check_capacity_error.outputs.capacity_error != 'true') &&
         failure() && steps.check_capacity_error.outputs.capacity_error != 'true'
         }}
-      uses: peter-evans/create-or-update-comment@v5.0.0
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       with:
         issue-number: ${{ inputs.issue_number }}
         body: |
@@ -478,7 +478,7 @@ runs:
 
     - name: comment (failed to associate IP with instance)
       if: ${{ steps.associated_ip.outcome == 'failure' && failure() }}
-      uses: peter-evans/create-or-update-comment@v5.0.0
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       with:
         issue-number: ${{ inputs.issue_number }}
         body: |

--- a/.github/actions/delete-volume/action.yml
+++ b/.github/actions/delete-volume/action.yml
@@ -43,7 +43,7 @@ runs:
       if:
         ${{ ! fromJSON(inputs.skip_approval_check) && !
         fromJSON(steps.check_approval.outputs.is_approved) }}
-      uses: peter-evans/create-or-update-comment@v4.0.0
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       with:
         issue-number: ${{ inputs.issue_number }}
         body: |
@@ -78,7 +78,7 @@ runs:
 
     - name: comment (volume does not exist)
       if: ${{ steps.check_volume.outputs.exists == 'false' }}
-      uses: peter-evans/create-or-update-comment@v4.0.0
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       with:
         issue-number: ${{ inputs.issue_number }}
         body: |
@@ -176,7 +176,7 @@ runs:
 
     - name: comment (failed to detach volume)
       if: ${{ steps.detach_volume.outcome == 'failure' && failure() }}
-      uses: peter-evans/create-or-update-comment@v4.0.0
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       with:
         issue-number: ${{ inputs.issue_number }}
         body: |
@@ -213,7 +213,7 @@ runs:
 
     - name: comment (failed to delete volume)
       if: ${{ steps.delete_volume.outcome == 'failure' && failure() }}
-      uses: peter-evans/create-or-update-comment@v4.0.0
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       with:
         issue-number: ${{ inputs.issue_number }}
         body: |
@@ -225,7 +225,7 @@ runs:
 
     - name: command results comment (success)
       if: ${{ steps.check_volume.outputs.exists == 'true' }}
-      uses: peter-evans/create-or-update-comment@v4.0.0
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       with:
         issue-number: ${{ inputs.issue_number }}
         body: |

--- a/.github/actions/extract-issue-fields/action.yml
+++ b/.github/actions/extract-issue-fields/action.yml
@@ -60,7 +60,7 @@ runs:
 
     - name: Issue Forms Body Parser
       id: parse
-      uses: zentered/issue-forms-body-parser@v2.2.0
+      uses: zentered/issue-forms-body-parser@93bd9fdcb3679be1889d2006e9c2cf496899402e # v2.2.0
       with:
         body: ${{ steps.read_issue_body.outputs.body }}
 

--- a/.github/actions/extract-workshop-fields/action.yml
+++ b/.github/actions/extract-workshop-fields/action.yml
@@ -48,7 +48,7 @@ runs:
 
     - name: Issue Forms Body Parser
       id: parse
-      uses: zentered/issue-forms-body-parser@v2.2.0
+      uses: zentered/issue-forms-body-parser@93bd9fdcb3679be1889d2006e9c2cf496899402e # v2.2.0
       with:
         body: ${{ steps.read_issue_body.outputs.body }}
 

--- a/.github/actions/setup-instance/action.yml
+++ b/.github/actions/setup-instance/action.yml
@@ -98,7 +98,7 @@ runs:
 
     - name: comment (maximum wait time exceeded)
       if: ${{ steps.instance_poll.outcome == 'failure' && failure() }}
-      uses: peter-evans/create-or-update-comment@v5.0.0
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       with:
         issue-number: ${{ inputs.issue_number }}
         body: |
@@ -186,7 +186,7 @@ runs:
 
     - name: comment (failed to rename MyData)
       if: ${{ steps.rename_mydata.outcome == 'failure' && failure() }}
-      uses: peter-evans/create-or-update-comment@v5.0.0
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       with:
         issue-number: ${{ inputs.issue_number }}
         body: |
@@ -230,7 +230,7 @@ runs:
 
     - name: comment (failed to attach volume)
       if: ${{ steps.attach_volume.outcome == 'failure' && failure() }}
-      uses: peter-evans/create-or-update-comment@v5.0.0
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       with:
         issue-number: ${{ inputs.issue_number }}
         body: |
@@ -281,7 +281,7 @@ runs:
 
     - name: comment (failed to copy installed files from MyData-tmp to MyData)
       if: ${{ steps.copy_installed_files.outcome == 'failure' && failure() }}
-      uses: peter-evans/create-or-update-comment@v5.0.0
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       with:
         issue-number: ${{ inputs.issue_number }}
         body: |
@@ -364,7 +364,7 @@ runs:
 
     - name: comment (failed to relocate home directory to persistent volume)
       if: ${{ steps.relocate_home_directory.outcome == 'failure' && failure() }}
-      uses: peter-evans/create-or-update-comment@v5.0.0
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       with:
         issue-number: ${{ inputs.issue_number }}
         body: |
@@ -389,7 +389,7 @@ runs:
 
     - name: comment (failed to create /home/exouser/.Renviron)
       if: ${{ steps.create_renviron_file.outcome == 'failure' && failure() }}
-      uses: peter-evans/create-or-update-comment@v5.0.0
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       with:
         issue-number: ${{ inputs.issue_number }}
         body: |
@@ -446,7 +446,7 @@ runs:
 
     - name: comment (failed to reboot instance)
       if: ${{ steps.reboot_instance.outcome == 'failure' && failure() }}
-      uses: peter-evans/create-or-update-comment@v5.0.0
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       with:
         issue-number: ${{ inputs.issue_number }}
         body: |
@@ -474,7 +474,7 @@ runs:
 
     - name: comment (failed to set instance properties)
       if: ${{ steps.set_instance_properties.outcome == 'failure' && failure() }}
-      uses: peter-evans/create-or-update-comment@v5.0.0
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       with:
         issue-number: ${{ inputs.issue_number }}
         body: |
@@ -497,7 +497,7 @@ runs:
       if:
         ${{ steps.update-request-status-label.outcome == 'failure' && failure()
         }}
-      uses: peter-evans/create-or-update-comment@v5.0.0
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       with:
         issue-number: ${{ inputs.issue_number }}
         body: |

--- a/.github/actions/update-approval/action.yml
+++ b/.github/actions/update-approval/action.yml
@@ -56,7 +56,7 @@ runs:
 
     - name: Comment (approval confirmation)
       if: ${{ inputs.command_name == 'approve' }}
-      uses: peter-evans/create-or-update-comment@v4
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       with:
         issue-number: ${{ inputs.issue_number }}
         body: |
@@ -66,7 +66,7 @@ runs:
 
     - name: command results comment (failure)
       if: ${{ failure() }}
-      uses: peter-evans/create-or-update-comment@v4.0.0
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       with:
         issue-number: ${{ inputs.issue_number }}
         body: |

--- a/.github/workflows/approve-workshop.yml
+++ b/.github/workflows/approve-workshop.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/create-github-app-token@v3.2.0
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: admin-token
         with:
           app-id: ${{ vars.MORPHOCLOUD_WORKFLOW_APP_ID }}
@@ -30,7 +30,7 @@ jobs:
           team_slug: morphocloud-admins
       - name: approve command
         id: approve_command
-        uses: github/command@v2.0.3
+        uses: github/command@3442f3fa1efe01bdb024b157083c337902d17372 # v2.0.3
         with:
           command: "/approve"
           reaction: "rocket"
@@ -40,7 +40,7 @@ jobs:
 
       - name: unapprove command
         id: unapprove_command
-        uses: github/command@v2.0.3
+        uses: github/command@3442f3fa1efe01bdb024b157083c337902d17372 # v2.0.3
         with:
           command: "/unapprove"
           reaction: "rocket"
@@ -78,7 +78,7 @@ jobs:
 
       - uses: actions/checkout@v6
 
-      - uses: actions/create-github-app-token@v3.2.0
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         if:
           ${{ steps.command.outputs.continue == 'true' &&
@@ -190,7 +190,7 @@ jobs:
         if:
           ${{ steps.command.outputs.continue == 'true' &&
           steps.command.outputs.command_name == 'approve' }}
-        uses: peter-evans/create-or-update-comment@v5.0.0
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           issue-number: ${{ github.event.issue.number }}
           body: |
@@ -204,7 +204,7 @@ jobs:
 
       - name: command results comment (failure)
         if: ${{ failure() }}
-        uses: peter-evans/create-or-update-comment@v5.0.0
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           issue-number: ${{ github.event.issue.number }}
           body: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,6 @@ jobs:
         with:
           python-version: "3.x"
 
-      - uses: pre-commit/action@v3.0.1
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         with:
           extra_args: --hook-stage manual --all-files

--- a/.github/workflows/control-instance.yml
+++ b/.github/workflows/control-instance.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/create-github-app-token@v3.2.0
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           app-id: ${{ vars.MORPHOCLOUD_WORKFLOW_APP_ID }}
@@ -38,7 +38,7 @@ jobs:
 
       - name: unshelve command
         id: unshelve_command
-        uses: github/command@v2.0.3
+        uses: github/command@3442f3fa1efe01bdb024b157083c337902d17372 # v2.0.3
         with:
           command: "/unshelve"
           reaction: "rocket"
@@ -51,7 +51,7 @@ jobs:
 
       - name: shelve command
         id: shelve_command
-        uses: github/command@v2.0.3
+        uses: github/command@3442f3fa1efe01bdb024b157083c337902d17372 # v2.0.3
         with:
           command: "/shelve"
           reaction: "rocket"
@@ -64,7 +64,7 @@ jobs:
 
       - name: delete command
         id: delete_command
-        uses: github/command@v2.0.3
+        uses: github/command@3442f3fa1efe01bdb024b157083c337902d17372 # v2.0.3
         with:
           command: "/delete_instance"
           reaction: "rocket"

--- a/.github/workflows/create-course-instance.yml
+++ b/.github/workflows/create-course-instance.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/create-github-app-token@v3.2.0
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: admin-token
         with:
           app-id: ${{ vars.MORPHOCLOUD_WORKFLOW_APP_ID }}
@@ -29,7 +29,7 @@ jobs:
           team_slug: morphocloud-admins
       - name: create command
         id: create_command
-        uses: github/command@v2.0.2
+        uses: github/command@3442f3fa1efe01bdb024b157083c337902d17372 # v2.0.3
         with:
           command: "/create"
           reaction: "rocket"
@@ -224,7 +224,7 @@ jobs:
 
       - name: comment (failed to send email)
         if: ${{ steps.send_email.outcome == 'failure' && failure() }}
-        uses: peter-evans/create-or-update-comment@v5.0.0
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           issue-number: ${{ github.event.issue.number }}
           body: |

--- a/.github/workflows/create-instance-from-workflow.yml
+++ b/.github/workflows/create-instance-from-workflow.yml
@@ -207,7 +207,7 @@ jobs:
 
       - name: comment (failed to send email)
         if: ${{ steps.send_email.outcome == 'failure' && failure() }}
-        uses: peter-evans/create-or-update-comment@v5.0.0
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           issue-number: ${{ inputs.issue_number }}
           body: |

--- a/.github/workflows/create-instance.yml
+++ b/.github/workflows/create-instance.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/create-github-app-token@v3.2.0
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: admin-token
         with:
           app-id: ${{ vars.MORPHOCLOUD_WORKFLOW_APP_ID }}
@@ -29,7 +29,7 @@ jobs:
           team_slug: morphocloud-admins
       - name: create command
         id: create_command
-        uses: github/command@v2.0.3
+        uses: github/command@3442f3fa1efe01bdb024b157083c337902d17372 # v2.0.3
         with:
           command: "/create"
           reaction: "rocket"
@@ -42,7 +42,7 @@ jobs:
 
       - uses: actions/checkout@v6
 
-      - uses: actions/create-github-app-token@v3.2.0
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           app-id: ${{ vars.MORPHOCLOUD_WORKFLOW_APP_ID }}
@@ -277,7 +277,7 @@ jobs:
 
       - name: comment (failed to send email)
         if: ${{ steps.send_email.outcome == 'failure' && failure() }}
-        uses: peter-evans/create-or-update-comment@v5.0.0
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           issue-number: ${{ github.event.issue.number }}
           body: |
@@ -302,7 +302,7 @@ jobs:
 
       - name: comment (retry guidance on provisioning failure)
         if: ${{ failure() && steps.provision.outcome == 'failure' }}
-        uses: peter-evans/create-or-update-comment@v5.0.0
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           issue-number: ${{ github.event.issue.number }}
           body: |

--- a/.github/workflows/create-workshop.yml
+++ b/.github/workflows/create-workshop.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/create-github-app-token@v3.2.0
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: admin-token
         with:
           app-id: ${{ vars.MORPHOCLOUD_WORKFLOW_APP_ID }}
@@ -33,7 +33,7 @@ jobs:
           team_slug: morphocloud-admins
       - name: create command
         id: create_command
-        uses: github/command@v2.0.3
+        uses: github/command@3442f3fa1efe01bdb024b157083c337902d17372 # v2.0.3
         with:
           command: "/create"
           reaction: "rocket"
@@ -55,7 +55,7 @@ jobs:
 
       - name: command results comment (Workflow management not approved)
         if: ${{ ! fromJSON(steps.check_approval.outputs.is_approved) }}
-        uses: peter-evans/create-or-update-comment@v5.0.0
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           issue-number: ${{ github.event.issue.number }}
           body: |

--- a/.github/workflows/delete-instance-and-volume.yml
+++ b/.github/workflows/delete-instance-and-volume.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/create-github-app-token@v3.2.0
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: admin-token
         with:
           app-id: ${{ vars.MORPHOCLOUD_WORKFLOW_APP_ID }}
@@ -29,7 +29,7 @@ jobs:
           team_slug: morphocloud-admins
       - name: delete_instance_and_volume command
         id: delete_instance_and_volume_command
-        uses: github/command@v2.0.3
+        uses: github/command@3442f3fa1efe01bdb024b157083c337902d17372 # v2.0.3
         with:
           command: "/delete_all"
           reaction: "rocket"

--- a/.github/workflows/delete-volume.yml
+++ b/.github/workflows/delete-volume.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/create-github-app-token@v3.2.0
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: admin-token
         with:
           app-id: ${{ vars.MORPHOCLOUD_WORKFLOW_APP_ID }}
@@ -29,7 +29,7 @@ jobs:
           team_slug: morphocloud-admins
       - name: delete_volume command
         id: delete_volume_command
-        uses: github/command@v2.0.3
+        uses: github/command@3442f3fa1efe01bdb024b157083c337902d17372 # v2.0.3
         with:
           command: "/delete_volume"
           reaction: "rocket"

--- a/.github/workflows/on-admin-mention.yml
+++ b/.github/workflows/on-admin-mention.yml
@@ -10,9 +10,14 @@ permissions:
 jobs:
   notify-on-mention:
     runs-on: ubuntu-latest
+    # Author-association gate: every MorphoCloud user is an org member, so
+    # this keeps the alert working for real users while stopping arbitrary
+    # accounts from pushing attacker-authored content into admin inboxes
+    # from the trusted sender (security review L1).
     if: >-
       contains(github.event.comment.body, '@MorphoCloud/morphocloud-admins') &&
-      github.event.comment.user.type != 'Bot'
+      github.event.comment.user.type != 'Bot' && contains(fromJSON('["OWNER",
+      "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
     steps:
       - name: Send mail (admin team mentioned)
         uses: dawidd6/action-send-mail@42942bc2f8fba4e611b459a018967a6a7c78c68c # v17

--- a/.github/workflows/on-course-request-opened.yml
+++ b/.github/workflows/on-course-request-opened.yml
@@ -55,7 +55,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/create-github-app-token@v3.2.0
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: admin-token
         with:
           app-id: ${{ vars.MORPHOCLOUD_WORKFLOW_APP_ID }}

--- a/.github/workflows/on-instance-request-opened.yml
+++ b/.github/workflows/on-instance-request-opened.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/create-github-app-token@v3.2.0
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           app-id: ${{ vars.MORPHOCLOUD_WORKFLOW_APP_ID }}
@@ -68,7 +68,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/create-github-app-token@v3.2.0
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: admin-token
         with:
           app-id: ${{ vars.MORPHOCLOUD_WORKFLOW_APP_ID }}
@@ -152,7 +152,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/create-github-app-token@v3.2.0
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           app-id: ${{ vars.MORPHOCLOUD_WORKFLOW_APP_ID }}
@@ -247,7 +247,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/create-github-app-token@v3.2.0
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           app-id: ${{ vars.MORPHOCLOUD_WORKFLOW_APP_ID }}

--- a/.github/workflows/request-initial-comments.yml
+++ b/.github/workflows/request-initial-comments.yml
@@ -53,7 +53,7 @@ jobs:
           issue_number: ${{ steps.collect_inputs.outputs.issue_number }}
 
       - name: description (instance name)
-        uses: julien-deramond/update-issue-body@v1.1.0
+        uses: julien-deramond/update-issue-body@a7fae45395cac5a23318d38f7b09a58650dfe84f # v1.1.0
         with:
           issue-number: ${{ steps.collect_inputs.outputs.issue_number }}
           body: |
@@ -73,7 +73,7 @@ jobs:
           suffix: ${{ vars.VOLUME_NAME_SUFFIX }}
 
       - name: description (volume name)
-        uses: julien-deramond/update-issue-body@v1.1.0
+        uses: julien-deramond/update-issue-body@a7fae45395cac5a23318d38f7b09a58650dfe84f # v1.1.0
         with:
           issue-number: ${{ steps.collect_inputs.outputs.issue_number }}
           body: |
@@ -86,7 +86,7 @@ jobs:
           append-separator: newline
 
       - name: Find Issue Commands Comment
-        uses: peter-evans/find-comment@v4
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4
         id: fc_commands
         with:
           issue-number: ${{ steps.collect_inputs.outputs.issue_number }}
@@ -94,7 +94,7 @@ jobs:
           body-includes: "### Supported Issue Commands"
 
       - name: comment (issue commands)
-        uses: peter-evans/create-or-update-comment@v5.0.0
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           comment-id: ${{ steps.fc_commands.outputs.comment-id }}
           issue-number: ${{ steps.collect_inputs.outputs.issue_number }}

--- a/.github/workflows/send-email.yml
+++ b/.github/workflows/send-email.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/create-github-app-token@v3.2.0
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: admin-token
         with:
           app-id: ${{ vars.MORPHOCLOUD_WORKFLOW_APP_ID }}
@@ -29,7 +29,7 @@ jobs:
           team_slug: morphocloud-admins
       - name: email command
         id: email_command
-        uses: github/command@v2.0.3
+        uses: github/command@3442f3fa1efe01bdb024b157083c337902d17372 # v2.0.3
         with:
           command: "/email"
           reaction: "rocket"
@@ -61,7 +61,7 @@ jobs:
         if:
           ${{ steps.email_command.outputs.continue == 'true' &&
           steps.check_instance.outputs.exists == 'false' }}
-        uses: peter-evans/create-or-update-comment@v5.0.0
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           issue-number: ${{ github.event.issue.number }}
           body: |
@@ -164,7 +164,7 @@ jobs:
           ${{ (steps.send_email.outcome == 'failure' ||
           steps.send_workshop_email.outcome == 'failure' ||
           steps.send_course_email.outcome == 'failure') && failure() }}
-        uses: peter-evans/create-or-update-comment@v5.0.0
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           issue-number: ${{ github.event.issue.number }}
           body: |
@@ -179,7 +179,7 @@ jobs:
           ${{ (steps.send_email.outcome == 'success' ||
           steps.send_workshop_email.outcome == 'success' ||
           steps.send_course_email.outcome == 'success') && success() }}
-        uses: peter-evans/create-or-update-comment@v5.0.0
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           issue-number: ${{ github.event.issue.number }}
           body: |

--- a/.github/workflows/send-renewal-email.yml
+++ b/.github/workflows/send-renewal-email.yml
@@ -58,7 +58,7 @@ jobs:
         if:
           ${{ steps.skip_check.outputs.is_course != 'true' &&
           steps.check_instance.outputs.exists == 'false' }}
-        uses: peter-evans/create-or-update-comment@v5.0.0
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           issue-number: ${{ inputs.issue_number }}
           body: |
@@ -237,7 +237,7 @@ jobs:
           ${{ steps.skip_check.outputs.is_course != 'true' &&
           (steps.send_email_renewable.outcome == 'failure' ||
           steps.send_email_final.outcome == 'failure') && failure() }}
-        uses: peter-evans/create-or-update-comment@v5.0.0
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           issue-number: ${{ inputs.issue_number }}
           body: |
@@ -250,7 +250,7 @@ jobs:
           ${{ steps.skip_check.outputs.is_course != 'true' &&
           (steps.send_email_renewable.outcome == 'success' ||
           steps.send_email_final.outcome == 'success') && success() }}
-        uses: peter-evans/create-or-update-comment@v5.0.0
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           issue-number: ${{ inputs.issue_number }}
           body: |

--- a/.github/workflows/update-renew-label.yml
+++ b/.github/workflows/update-renew-label.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/create-github-app-token@v3.2.0
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: admin-token
         with:
           app-id: ${{ vars.MORPHOCLOUD_WORKFLOW_APP_ID }}
@@ -35,7 +35,7 @@ jobs:
           team_slug: morphocloud-admins
       - name: renew command
         id: renew_command
-        uses: github/command@v2.0.3
+        uses: github/command@3442f3fa1efe01bdb024b157083c337902d17372 # v2.0.3
         with:
           command: "/renew"
           reaction: "rocket"
@@ -128,7 +128,7 @@ jobs:
 
       - name: command results comment (failed)
         if: ${{ steps.update_renew_label.outcome == 'failure' && failure() }}
-        uses: peter-evans/create-or-update-comment@v5.0.0
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           issue-number: ${{ github.event.issue.number }}
           body: |

--- a/.github/workflows/validate-command-course.yml
+++ b/.github/workflows/validate-command-course.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Validation results comment
         id: validate_comment
         if: ${{ steps.validate-course.outcome == 'failure' && failure() }}
-        uses: peter-evans/create-or-update-comment@v5.0.0
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           issue-number: ${{ github.event.issue.number }}
           body: |
@@ -61,7 +61,7 @@ jobs:
 
       - name: Append supported commands to failure comment
         if: ${{ steps.validate-course.outcome == 'failure' && failure() }}
-        uses: peter-evans/create-or-update-comment@v5.0.0
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           comment-id: ${{ steps.validate_comment.outputs.comment-id }}
           issue-number: ${{ github.event.issue.number }}
@@ -70,7 +70,7 @@ jobs:
 
       - name: Append action run link to failure comment
         if: ${{ steps.validate-course.outcome == 'failure' && failure() }}
-        uses: peter-evans/create-or-update-comment@v5.0.0
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           comment-id: ${{ steps.validate_comment.outputs.comment-id }}
           issue-number: ${{ github.event.issue.number }}

--- a/.github/workflows/validate-command-instance.yml
+++ b/.github/workflows/validate-command-instance.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Validation results comment
         id: validate_comment
         if: ${{ steps.validate-instance.outcome == 'failure' && failure() }}
-        uses: peter-evans/create-or-update-comment@v5.0.0
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           issue-number: ${{ github.event.issue.number }}
           body: |
@@ -62,7 +62,7 @@ jobs:
 
       - name: Append supported commands to failure comment
         if: ${{ steps.validate-instance.outcome == 'failure' && failure() }}
-        uses: peter-evans/create-or-update-comment@v5.0.0
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           comment-id: ${{ steps.validate_comment.outputs.comment-id }}
           issue-number: ${{ github.event.issue.number }}
@@ -71,7 +71,7 @@ jobs:
 
       - name: Append action run link to failure comment
         if: ${{ steps.validate-instance.outcome == 'failure' && failure() }}
-        uses: peter-evans/create-or-update-comment@v5.0.0
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           comment-id: ${{ steps.validate_comment.outputs.comment-id }}
           issue-number: ${{ github.event.issue.number }}

--- a/.github/workflows/validate-command-workshop.yml
+++ b/.github/workflows/validate-command-workshop.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Validation results comment
         id: validate_comment
         if: ${{ steps.validate-workshop.outcome == 'failure' && failure() }}
-        uses: peter-evans/create-or-update-comment@v5.0.0
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           issue-number: ${{ github.event.issue.number }}
           body: |
@@ -57,7 +57,7 @@ jobs:
 
       - name: Append supported commands to failure comment
         if: ${{ steps.validate-workshop.outcome == 'failure' && failure() }}
-        uses: peter-evans/create-or-update-comment@v5.0.0
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           comment-id: ${{ steps.validate_comment.outputs.comment-id }}
           issue-number: ${{ github.event.issue.number }}
@@ -66,7 +66,7 @@ jobs:
 
       - name: Append action run link to failure comment
         if: ${{ steps.validate-workshop.outcome == 'failure' && failure() }}
-        uses: peter-evans/create-or-update-comment@v5.0.0
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           comment-id: ${{ steps.validate_comment.outputs.comment-id }}
           issue-number: ${{ github.event.issue.number }}

--- a/.github/workflows/validate-request-course.yml
+++ b/.github/workflows/validate-request-course.yml
@@ -18,14 +18,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Find existing validation comment
-        uses: peter-evans/find-comment@v4
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4
         id: fc
         with:
           issue-number: ${{ inputs.issue_number }}
           body-includes: "### Validation Results"
 
       - name: Post validation success comment
-        uses: peter-evans/create-or-update-comment@v5.0.0
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ inputs.issue_number }}

--- a/.github/workflows/validate-request.yml
+++ b/.github/workflows/validate-request.yml
@@ -71,7 +71,7 @@ jobs:
       # --- Validation result comments ---
 
       - name: find command results comment
-        uses: peter-evans/find-comment@v4
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4
         id: fc
         with:
           issue-number: ${{ steps.collect_inputs.outputs.issue_number }}
@@ -79,7 +79,7 @@ jobs:
 
       - name: command results comment (instance - success)
         if: ${{ steps.request_type.outputs.is_workshop != 'true' && success() }}
-        uses: peter-evans/create-or-update-comment@v5.0.0
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ steps.collect_inputs.outputs.issue_number }}
@@ -91,7 +91,7 @@ jobs:
 
       - name: command results comment (failure)
         if: ${{ failure() }}
-        uses: peter-evans/create-or-update-comment@v5.0.0
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           issue-number: ${{ steps.collect_inputs.outputs.issue_number }}
           comment-id: ${{ steps.fc.outputs.comment-id }}
@@ -105,7 +105,7 @@ jobs:
 
       - name: command results comment (workshop - success)
         if: ${{ steps.request_type.outputs.is_workshop == 'true' && success() }}
-        uses: peter-evans/create-or-update-comment@v5.0.0
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ steps.collect_inputs.outputs.issue_number }}

--- a/.github/workflows/workshop-backfill.yml
+++ b/.github/workflows/workshop-backfill.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/create-github-app-token@v3.2.0
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           app-id: ${{ vars.MORPHOCLOUD_WORKFLOW_APP_ID }}


### PR DESCRIPTION
Security review M6 + L1: SHA-pins all 103 third-party action uses (collapsing the v4/v5 and v2.0.2/v2.0.3 skews), and gates on-admin-mention to org members/collaborators. The `app-id`→`client-id` rename is deferred — `client-id` expects a different value (Iv1.*) than the numeric App ID and needs verification first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)