### PR TITLE
Align send-mail to v17 in composite actions; cover them in dependabot

### DIFF
--- a/.github/actions/course-send-email/action.yml
+++ b/.github/actions/course-send-email/action.yml
@@ -90,7 +90,7 @@ runs:
         instance_ip: ${{ steps.instance_metadata.outputs.instance_ip }}
 
     - name: Send mail
-      uses: dawidd6/action-send-mail@62a2d05b79935ad4fb90ce9079928099579c14ac # v9
+      uses: dawidd6/action-send-mail@42942bc2f8fba4e611b459a018967a6a7c78c68c # v17
       with:
         server_address: webhost.dynadot.com
         server_port: 587

--- a/.github/actions/send-email/action.yml
+++ b/.github/actions/send-email/action.yml
@@ -62,7 +62,7 @@ runs:
         instance_ip: ${{ steps.instance_metadata.outputs.instance_ip }}
 
     - name: Send mail
-      uses: dawidd6/action-send-mail@62a2d05b79935ad4fb90ce9079928099579c14ac # v9
+      uses: dawidd6/action-send-mail@42942bc2f8fba4e611b459a018967a6a7c78c68c # v17
       with:
         server_address: webhost.dynadot.com
         server_port: 587

--- a/.github/actions/send-workshop-email-approval/action.yml
+++ b/.github/actions/send-workshop-email-approval/action.yml
@@ -43,7 +43,7 @@ runs:
         issue_number: ${{ inputs.workshop_issue_number }}
 
     - name: Send approval mail
-      uses: dawidd6/action-send-mail@62a2d05b79935ad4fb90ce9079928099579c14ac # v9
+      uses: dawidd6/action-send-mail@42942bc2f8fba4e611b459a018967a6a7c78c68c # v17
       with:
         server_address: webhost.dynadot.com
         server_port: 587

--- a/.github/actions/workshop-send-email/action.yml
+++ b/.github/actions/workshop-send-email/action.yml
@@ -84,7 +84,7 @@ runs:
         instance_ip: ${{ steps.instance_metadata.outputs.instance_ip }}
 
     - name: Send mail
-      uses: dawidd6/action-send-mail@62a2d05b79935ad4fb90ce9079928099579c14ac # v9
+      uses: dawidd6/action-send-mail@42942bc2f8fba4e611b459a018967a6a7c78c68c # v17
       with:
         server_address: webhost.dynadot.com
         server_port: 587

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,11 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
+  # Composite actions are not covered by the "/" entry — without this,
+  # bumps land in workflows but silently skip .github/actions/* (this is
+  # how send-mail v9/v17 skew happened).
+  - package-ecosystem: "github-actions"
+    directories:
+      - "/.github/actions/*"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Closes the v9/v17 send-mail skew the #198 review flagged: the four composite actions (credential-email senders) were missed by #191 because Dependabot's `/` entry doesn't scan `.github/actions/*`. Aligns the pins and adds a dependabot directories entry so this can't recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)