### PR TITLE
Gate command workflows: authorize on GitHub-hosted before self-hosted runs

### DIFF
--- a/.github/workflows/control-instance.yml
+++ b/.github/workflows/control-instance.yml
@@ -10,15 +10,22 @@ permissions:
   checks: read
   contents: read
 
+# Two-job split (security review M3): authorization runs first on a
+# GitHub-hosted runner; nothing executes on the self-hosted runner — no
+# checkout, no privileged steps — until the command is authorized. This keeps
+# unauthorized commenters from occupying the production runners.
 jobs:
-  control:
-    runs-on: self-hosted
+  authorize:
+    runs-on: ubuntu-latest
     if:
       ${{ !github.event.issue.pull_request &&
       contains(github.event.issue.labels.*.name, 'instance-request') && (
       contains(github.event.comment.body, '/unshelve') ||
       contains(github.event.comment.body, '/shelve') ||
       contains(github.event.comment.body, '/delete_instance') ) }}
+    outputs:
+      continue: ${{ steps.command.outputs.continue }}
+      command_name: ${{ steps.command.outputs.command_name }}
     steps:
       - uses: actions/checkout@v6
 
@@ -85,32 +92,33 @@ jobs:
           if [[ "$UNSHELVE_COMMAND_CONTINUE" == "true" ]]; then
             continue="$UNSHELVE_COMMAND_CONTINUE"
             command_name="unshelve"
-            comment_id="${{ steps.unshelve_command.outputs.comment_id }}"
           elif [[ "$SHELVE_COMMAND_CONTINUE" == "true" ]]; then
             continue="$SHELVE_COMMAND_CONTINUE"
             command_name="shelve"
-            comment_id="${{ steps.shelve_command.outputs.comment_id }}"
           elif [[ "$DELETE_COMMAND_CONTINUE" == "true" ]]; then
             continue="$DELETE_COMMAND_CONTINUE"
             command_name="delete"
-            comment_id="${{ steps.delete_command.outputs.comment_id }}"
           else
             continue="false"
             command_name=""
-            comment_id=""
           fi
           echo "continue=$continue" >> $GITHUB_OUTPUT
           echo "command_name=$command_name" >> $GITHUB_OUTPUT
-          echo "comment_id=$comment_id" >> $GITHUB_OUTPUT
         env:
           UNSHELVE_COMMAND_CONTINUE:
             ${{ steps.unshelve_command.outputs.continue }}
           SHELVE_COMMAND_CONTINUE: ${{ steps.shelve_command.outputs.continue }}
           DELETE_COMMAND_CONTINUE: ${{ steps.delete_command.outputs.continue }}
 
+  control:
+    runs-on: self-hosted
+    needs: authorize
+    if: ${{ needs.authorize.outputs.continue == 'true' }}
+    steps:
+      - uses: actions/checkout@v6
+
       - name: Check JS2 status
         id: js2_status
-        if: ${{ steps.command.outputs.continue == 'true' }}
         uses: ./.github/actions/check-js2-status
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -118,12 +126,11 @@ jobs:
 
       - name: Control instance
         id: control_instance
-        if: ${{ steps.command.outputs.continue == 'true' }}
         uses: ./.github/actions/control-instance
         with:
           os_cloud: ${{ vars.MORPHOCLOUD_OS_CLOUD }}
           issue_number: ${{ github.event.issue.number }}
-          command_name: ${{ steps.command.outputs.command_name }}
+          command_name: ${{ needs.authorize.outputs.command_name }}
           instance_name_prefix: ${{ vars.INSTANCE_NAME_PREFIX }}
           token: ${{ secrets.GITHUB_TOKEN }}
           email_lookup_url: ${{ vars.MORPHOCLOUD_EMAIL_LOOKUP_URL }}

--- a/.github/workflows/create-instance.yml
+++ b/.github/workflows/create-instance.yml
@@ -4,13 +4,23 @@ on:
   issue_comment:
     types: [created]
 
+# Two-job split (security review M3): authorization runs first on a
+# GitHub-hosted runner; the acquire runner is only occupied — and nothing is
+# checked out or provisioned — once /create is authorized. The job-level gate
+# on the execute job also closes a latent hole: a comment that merely
+# mentioned "/create" mid-sentence used to fall through to provisioning
+# because github/command's strict prefix match returned continue=false
+# without failing the job.
 jobs:
-  create:
-    runs-on: ${{ vars.MORPHOCLOUD_ACQUIRE_RUNNER || 'self-hosted' }}
+  authorize:
+    runs-on: ubuntu-latest
     if:
       ${{ !github.event.issue.pull_request &&
       contains(github.event.issue.labels.*.name, 'request-type:instance') && (
       contains(github.event.comment.body, '/create') ) }}
+    outputs:
+      continue: ${{ steps.create_command.outputs.continue }}
+      admins: ${{ steps.admins.outputs.members }}
     steps:
       - uses: actions/checkout@v6
 
@@ -27,6 +37,7 @@ jobs:
           token: ${{ steps.admin-token.outputs.token }}
           org: ${{ github.repository_owner }}
           team_slug: morphocloud-admins
+
       - name: create command
         id: create_command
         uses: github/command@3442f3fa1efe01bdb024b157083c337902d17372 # v2.0.3
@@ -40,6 +51,11 @@ jobs:
             github.event.issue.user.login }},${{
             join(github.event.issue.assignees.*.login, ',') }}"
 
+  create:
+    runs-on: ${{ vars.MORPHOCLOUD_ACQUIRE_RUNNER || 'self-hosted' }}
+    needs: authorize
+    if: ${{ needs.authorize.outputs.continue == 'true' }}
+    steps:
       - uses: actions/checkout@v6
 
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -113,7 +129,7 @@ jobs:
             'request-creator:workshop') }}
           ASSIGNEES: ${{ join(github.event.issue.assignees.*.login, ',') }}
           COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
-          ADMINS: ${{ steps.admins.outputs.members }}
+          ADMINS: ${{ needs.authorize.outputs.admins }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
@@ -220,7 +236,7 @@ jobs:
             ${{ contains(github.event.issue.labels.*.name,
             'request-creator:workshop') }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
-          ADMINS: ${{ steps.admins.outputs.members }}
+          ADMINS: ${{ needs.authorize.outputs.admins }}
           MAX_PER_USER: ${{ vars.MORPHOCLOUD_MAX_INSTANCES_PER_USER }}
           MAX_TOTAL: ${{ vars.MORPHOCLOUD_MAX_TOTAL_INSTANCES }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/delete-instance-and-volume.yml
+++ b/.github/workflows/delete-instance-and-volume.yml
@@ -4,13 +4,18 @@ on:
   issue_comment:
     types: [created]
 
+# Two-job split (security review M3): authorization runs first on a
+# GitHub-hosted runner; the self-hosted runner is only occupied once
+# /delete_all is authorized.
 jobs:
-  delete_instance_and_volume:
-    runs-on: self-hosted
+  authorize:
+    runs-on: ubuntu-latest
     if:
       ${{ !github.event.issue.pull_request &&
       contains(github.event.issue.labels.*.name, 'instance-request') && (
       contains(github.event.comment.body, '/delete_all') ) }}
+    outputs:
+      continue: ${{ steps.delete_instance_and_volume_command.outputs.continue }}
     steps:
       - uses: actions/checkout@v6
 
@@ -27,6 +32,7 @@ jobs:
           token: ${{ steps.admin-token.outputs.token }}
           org: ${{ github.repository_owner }}
           team_slug: morphocloud-admins
+
       - name: delete_instance_and_volume command
         id: delete_instance_and_volume_command
         uses: github/command@3442f3fa1efe01bdb024b157083c337902d17372 # v2.0.3
@@ -40,13 +46,15 @@ jobs:
             vars.COURSE_INSTRUCTOR_GITHUB }},${{ github.event.issue.user.login
             }},${{ join(github.event.issue.assignees.*.login, ',') }}"
 
+  delete_instance_and_volume:
+    runs-on: self-hosted
+    needs: authorize
+    if: ${{ needs.authorize.outputs.continue == 'true' }}
+    steps:
       - uses: actions/checkout@v6
 
       - name: Delete volume
         id: delete_volume
-        if:
-          ${{ steps.delete_instance_and_volume_command.outputs.continue ==
-          'true' }}
         uses: ./.github/actions/delete-volume
         with:
           os_cloud: ${{ vars.MORPHOCLOUD_OS_CLOUD }}
@@ -57,9 +65,6 @@ jobs:
 
       - name: Delete instance
         id: delete_instance
-        if:
-          ${{ steps.delete_instance_and_volume_command.outputs.continue ==
-          'true' }}
         uses: ./.github/actions/control-instance
         with:
           os_cloud: ${{ vars.MORPHOCLOUD_OS_CLOUD }}

--- a/.github/workflows/delete-volume.yml
+++ b/.github/workflows/delete-volume.yml
@@ -4,13 +4,18 @@ on:
   issue_comment:
     types: [created]
 
+# Two-job split (security review M3): authorization runs first on a
+# GitHub-hosted runner; the self-hosted runner is only occupied once
+# /delete_volume is authorized.
 jobs:
-  delete_volume:
-    runs-on: self-hosted
+  authorize:
+    runs-on: ubuntu-latest
     if:
       ${{ !github.event.issue.pull_request &&
       contains(github.event.issue.labels.*.name, 'instance-request') && (
       contains(github.event.comment.body, '/delete_volume') ) }}
+    outputs:
+      continue: ${{ steps.delete_volume_command.outputs.continue }}
     steps:
       - uses: actions/checkout@v6
 
@@ -27,6 +32,7 @@ jobs:
           token: ${{ steps.admin-token.outputs.token }}
           org: ${{ github.repository_owner }}
           team_slug: morphocloud-admins
+
       - name: delete_volume command
         id: delete_volume_command
         uses: github/command@3442f3fa1efe01bdb024b157083c337902d17372 # v2.0.3
@@ -40,11 +46,15 @@ jobs:
             vars.COURSE_INSTRUCTOR_GITHUB }},${{ github.event.issue.user.login
             }}"
 
+  delete_volume:
+    runs-on: self-hosted
+    needs: authorize
+    if: ${{ needs.authorize.outputs.continue == 'true' }}
+    steps:
       - uses: actions/checkout@v6
 
       - name: Delete volume
         id: delete_volume
-        if: ${{ steps.delete_volume_command.outputs.continue == 'true' }}
         uses: ./.github/actions/delete-volume
         with:
           os_cloud: ${{ vars.MORPHOCLOUD_OS_CLOUD }}

--- a/.github/workflows/send-email.yml
+++ b/.github/workflows/send-email.yml
@@ -4,13 +4,20 @@ on:
   issue_comment:
     types: [created]
 
+# Two-job split (security review M3): authorization runs first on a
+# GitHub-hosted runner; the self-hosted runner is only occupied once /email
+# is authorized. The job-level gate also ensures a comment that merely
+# mentions "/email" mid-sentence (strict prefix match fails -> continue=false)
+# can no longer fall through to the send steps.
 jobs:
-  send-email:
-    runs-on: self-hosted
+  authorize:
+    runs-on: ubuntu-latest
     if:
       ${{ !github.event.issue.pull_request &&
       contains(github.event.issue.labels.*.name, 'instance-request') && (
       contains(github.event.comment.body, '/email') ) }}
+    outputs:
+      continue: ${{ steps.email_command.outputs.continue }}
     steps:
       - uses: actions/checkout@v6
 
@@ -27,6 +34,7 @@ jobs:
           token: ${{ steps.admin-token.outputs.token }}
           org: ${{ github.repository_owner }}
           team_slug: morphocloud-admins
+
       - name: email command
         id: email_command
         uses: github/command@3442f3fa1efe01bdb024b157083c337902d17372 # v2.0.3
@@ -40,6 +48,11 @@ jobs:
             vars.COURSE_INSTRUCTOR_GITHUB }},${{ github.event.issue.user.login
             }}"
 
+  send-email:
+    runs-on: self-hosted
+    needs: authorize
+    if: ${{ needs.authorize.outputs.continue == 'true' }}
+    steps:
       - uses: actions/checkout@v6
 
       - name: Define instance name
@@ -51,16 +64,13 @@ jobs:
 
       - name: Check instance exists
         id: check_instance
-        if: ${{ steps.email_command.outputs.continue == 'true' }}
         uses: ./.github/actions/check-instance-exists
         with:
           os_cloud: ${{ vars.MORPHOCLOUD_OS_CLOUD }}
           instance_name: ${{ steps.define.outputs.instance_name }}
 
       - name: command results comment (Instance does not exist)
-        if:
-          ${{ steps.email_command.outputs.continue == 'true' &&
-          steps.check_instance.outputs.exists == 'false' }}
+        if: ${{ steps.check_instance.outputs.exists == 'false' }}
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           issue-number: ${{ github.event.issue.number }}


### PR DESCRIPTION
Security review M3: two-job authorization gate for all five issue-comment command workflows. The self-hosted runners see nothing — no checkout, no App token, no occupied slot — until github/command authorizes the commenter on a GitHub-hosted gate job. Also fixes the latent fall-through where a mid-sentence command mention bypassed the continue gate in create-instance/send-email.

Reactions, rejection comments, and results comments unchanged. E2E validation on Test-Instances to follow before go-live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)