### PR TITLE
Address M3 review findings

### DIFF
--- a/.github/workflows/control-instance.yml
+++ b/.github/workflows/control-instance.yml
@@ -82,12 +82,11 @@ jobs:
             vars.COURSE_INSTRUCTOR_GITHUB }},${{ github.event.issue.user.login
             }},${{ join(github.event.issue.assignees.*.login, ',') }}"
 
+      # No if-guard: always runs so the job output is an explicit "false"
+      # (a skipped step would yield "" — confusing, and an authorization
+      # bypass if the downstream gate were ever relaxed to != 'false').
       - name: Set command metadata
         id: command
-        if:
-          ${{ steps.unshelve_command.outputs.continue == 'true' ||
-          steps.shelve_command.outputs.continue == 'true' ||
-          steps.delete_command.outputs.continue == 'true' }}
         run: |
           if [[ "$UNSHELVE_COMMAND_CONTINUE" == "true" ]]; then
             continue="$UNSHELVE_COMMAND_CONTINUE"

--- a/.github/workflows/create-instance.yml
+++ b/.github/workflows/create-instance.yml
@@ -4,6 +4,11 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  issues: write
+  checks: read
+  contents: read
+
 # Two-job split (security review M3): authorization runs first on a
 # GitHub-hosted runner; the acquire runner is only occupied — and nothing is
 # checked out or provisioned — once /create is authorized. The job-level gate
@@ -140,9 +145,10 @@ jobs:
         run: |
           MAX_PER_USER="${MAX_PER_USER:-2}"
           MAX_TOTAL="${MAX_TOTAL:-90}"
-          # Admin bypass
-          if echo ",$ADMINS," | grep -q ",$ISSUE_CREATOR,"; then
-            echo "Admin $ISSUE_CREATOR — skipping quota check."
+          # Admin bypass — keyed on whoever ran /create (an admin acting on a
+          # user's issue overrides the quota), not the issue creator
+          if echo ",$ADMINS," | grep -q ",$COMMENT_AUTHOR,"; then
+            echo "Admin $COMMENT_AUTHOR — skipping quota check."
             exit 0
           fi
 
@@ -232,6 +238,7 @@ jobs:
           OS_CLOUD: ${{ vars.MORPHOCLOUD_OS_CLOUD }}
           INSTANCE_NAME_PREFIX: ${{ vars.INSTANCE_NAME_PREFIX }}
           ISSUE_CREATOR: ${{ github.event.issue.user.login }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
           IS_WORKSHOP:
             ${{ contains(github.event.issue.labels.*.name,
             'request-creator:workshop') }}

--- a/.github/workflows/delete-instance-and-volume.yml
+++ b/.github/workflows/delete-instance-and-volume.yml
@@ -4,6 +4,11 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  issues: write
+  checks: read
+  contents: read
+
 # Two-job split (security review M3): authorization runs first on a
 # GitHub-hosted runner; the self-hosted runner is only occupied once
 # /delete_all is authorized.

--- a/.github/workflows/delete-volume.yml
+++ b/.github/workflows/delete-volume.yml
@@ -4,6 +4,11 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  issues: write
+  checks: read
+  contents: read
+
 # Two-job split (security review M3): authorization runs first on a
 # GitHub-hosted runner; the self-hosted runner is only occupied once
 # /delete_volume is authorized.

--- a/.github/workflows/send-email.yml
+++ b/.github/workflows/send-email.yml
@@ -4,6 +4,11 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  issues: write
+  checks: read
+  contents: read
+
 # Two-job split (security review M3): authorization runs first on a
 # GitHub-hosted runner; the self-hosted runner is only occupied once /email
 # is authorized. The job-level gate also ensures a comment that merely


### PR DESCRIPTION
Fixes the three findings from #201's review: explicit 'false' continue output in control-instance, quota admin-bypass keyed on the comment author, and explicit permissions blocks on the four command workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)