### PR TITLE
fix: Repin claude-code-action to the dereferenced commit SHA

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 1
 
       - name: Claude review
-        uses: anthropics/claude-code-action@b2532c6eeaeae7a645f37943ed5a7e51870d1d90 # v1
+        uses: anthropics/claude-code-action@11ba60486e4aec9ddfeafcf4bb3f00b028ac2c16 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: true

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,6 +35,6 @@ jobs:
           fetch-depth: 1
 
       - name: Run Claude Code
-        uses: anthropics/claude-code-action@b2532c6eeaeae7a645f37943ed5a7e51870d1d90 # v1
+        uses: anthropics/claude-code-action@11ba60486e4aec9ddfeafcf4bb3f00b028ac2c16 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
b2532c6 is the v1 annotated-tag object, not a commit, so it lacked the
immutability guarantee of a commit pin.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
