### PR TITLE
feat: Course readiness — gate split + custom exosphere ref (M7, #194)

### DIFF
--- a/.github/workflows/create-course-instance.yml
+++ b/.github/workflows/create-course-instance.yml
@@ -4,13 +4,27 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  issues: write
+  checks: read
+  contents: read
+
+# Two-job split (security review M3/M7): authorization runs first on a
+# GitHub-hosted runner; the self-hosted runner is only occupied — and nothing
+# is checked out or provisioned — once /create is authorized. The job-level
+# gate also closes the fall-through where a comment merely mentioning
+# "/create" mid-sentence (strict prefix match fails -> continue=false)
+# proceeded to provisioning.
 jobs:
-  create:
-    runs-on: ${{ vars.MORPHOCLOUD_ACQUIRE_RUNNER || 'self-hosted' }}
+  authorize:
+    runs-on: ubuntu-latest
     if:
       ${{ !github.event.issue.pull_request &&
       contains(github.event.issue.labels.*.name, 'request-type:course-instance')
       && ( contains(github.event.comment.body, '/create') ) }}
+    outputs:
+      continue: ${{ steps.create_command.outputs.continue }}
+      admins: ${{ steps.admins.outputs.members }}
     steps:
       - uses: actions/checkout@v6
 
@@ -27,6 +41,7 @@ jobs:
           token: ${{ steps.admin-token.outputs.token }}
           org: ${{ github.repository_owner }}
           team_slug: morphocloud-admins
+
       - name: create command
         id: create_command
         uses: github/command@3442f3fa1efe01bdb024b157083c337902d17372 # v2.0.3
@@ -40,7 +55,75 @@ jobs:
             vars.COURSE_INSTRUCTOR_GITHUB }},${{ github.event.issue.user.login
             }},${{ join(github.event.issue.assignees.*.login, ',') }}"
 
+  create:
+    runs-on: ${{ vars.MORPHOCLOUD_ACQUIRE_RUNNER || 'self-hosted' }}
+    needs: authorize
+    if: ${{ needs.authorize.outputs.continue == 'true' }}
+    steps:
       - uses: actions/checkout@v6
+
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          app-id: ${{ vars.MORPHOCLOUD_WORKFLOW_APP_ID }}
+          private-key: ${{ secrets.MORPHOCLOUD_WORKFLOW_APP_PRIVATE_KEY }}
+
+      - name: Check authorization
+        id: check_auth
+        shell: bash
+        run: |
+          # An admin running the command is always authorized.
+          if echo ",$ADMINS," | grep -q ",$COMMENT_AUTHOR,"; then
+            echo "Admin $COMMENT_AUTHOR — authorized."
+            exit 0
+          fi
+
+          # The instructor self-tests /create before the roster/team is
+          # populated, so they are authorized on their own issue by identity.
+          if [[ -n "$COURSE_INSTRUCTOR" && "$ISSUE_CREATOR" == "$COURSE_INSTRUCTOR" ]]; then
+            echo "Issue creator is the course instructor — authorized."
+            exit 0
+          fi
+
+          if [[ -z "$COURSE_TEAM_SLUG" ]]; then
+            echo "::error ::COURSE_TEAM_SLUG is not configured for this repo"
+            exit 1
+          fi
+
+          ENCODED_SUBJECT=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1]))" "$ISSUE_CREATOR")
+          HTTP_CODE=$(curl -s --retry 3 --retry-delay 5 --retry-all-errors -o /tmp/membership_response.json -w "%{http_code}" \
+            -H "Authorization: Bearer $APP_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/orgs/$ORG/teams/$COURSE_TEAM_SLUG/memberships/$ENCODED_SUBJECT") || true
+
+          authorized="false"
+          if [[ "$HTTP_CODE" == "200" ]]; then
+            STATE=$(jq -r '.state' /tmp/membership_response.json)
+            if [[ "$STATE" == "active" ]]; then
+              authorized="true"
+            fi
+          fi
+          rm -f /tmp/membership_response.json
+
+          if [[ "$authorized" != "true" ]]; then
+            gh issue comment "$ISSUE_NUMBER" --body "### Command Results ❌
+
+          @${ISSUE_CREATOR} is not an enrolled member of this course's team (\`${COURSE_TEAM_SLUG}\`), so \`/create\` cannot proceed. Please contact your instructor."
+            echo "::error ::User $ISSUE_CREATOR is not an active member of $COURSE_TEAM_SLUG"
+            exit 1
+          fi
+        env:
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          ORG: ${{ github.repository_owner }}
+          COURSE_TEAM_SLUG: ${{ vars.COURSE_TEAM_SLUG }}
+          COURSE_INSTRUCTOR: ${{ vars.COURSE_INSTRUCTOR_GITHUB }}
+          ISSUE_CREATOR: ${{ github.event.issue.user.login }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          ADMINS: ${{ needs.authorize.outputs.admins }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
 
       - name: Check course instance quota
         id: check_quota
@@ -48,9 +131,10 @@ jobs:
         run: |
           MAX_COURSE_PER_USER="${MAX_COURSE_PER_USER:-1}"
           MAX_TOTAL="${MAX_TOTAL:-90}"
-          # Admin bypass
-          if echo ",$ADMINS," | grep -q ",$ISSUE_CREATOR,"; then
-            echo "Admin $ISSUE_CREATOR — skipping quota check."
+          # Admin bypass — keyed on whoever ran /create (an admin acting on a
+          # user's issue overrides the quota), not the issue creator
+          if echo ",$ADMINS," | grep -q ",$COMMENT_AUTHOR,"; then
+            echo "Admin $COMMENT_AUTHOR — skipping quota check."
             exit 0
           fi
 
@@ -162,8 +246,9 @@ jobs:
           OS_CLOUD: ${{ vars.MORPHOCLOUD_OS_CLOUD }}
           INSTANCE_NAME_PREFIX: ${{ vars.INSTANCE_NAME_PREFIX }}
           ISSUE_CREATOR: ${{ github.event.issue.user.login }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
-          ADMINS: ${{ steps.admins.outputs.members }}
+          ADMINS: ${{ needs.authorize.outputs.admins }}
           COURSE_INSTRUCTOR: ${{ vars.COURSE_INSTRUCTOR_GITHUB }}
           MAX_COURSE_PER_USER:
             ${{ vars.MORPHOCLOUD_MAX_COURSE_INSTANCES_PER_USER }}
@@ -178,6 +263,54 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue_number: ${{ github.event.issue.number }}
+
+      # Course software customization (#194): optional per-course repo variable
+      # MORPHOCLOUD_EXOSPHERE_REF = full commit SHA on MorphoCloud/exosphere
+      # (normally the HEAD of the course's course/<slug> branch). Absent
+      # variable = the standard vendorized pin. The committed cloud-config
+      # stays generic and the variable survives vendorize.
+      - name: Apply custom exosphere ref
+        id: custom_ref
+        shell: bash
+        run: |
+          if [[ -z "$EXOSPHERE_REF" ]]; then
+            echo "MORPHOCLOUD_EXOSPHERE_REF not set — standard image."
+            exit 0
+          fi
+
+          # The regex — not the API call, which also resolves branch names and
+          # short SHAs — is what enforces the full-immutable-SHA rule; it also
+          # makes the sed below injection-proof.
+          if ! [[ "$EXOSPHERE_REF" =~ ^[0-9a-f]{40}$ ]]; then
+            gh issue comment "$ISSUE_NUMBER" --body "### Command Results ❌
+
+          \`MORPHOCLOUD_EXOSPHERE_REF\` is set but is not a full 40-character lowercase commit SHA. No instance was created. Please tag @MorphoCloud/morphocloud-admins."
+            echo "::error ::MORPHOCLOUD_EXOSPHERE_REF is not a full commit SHA"
+            exit 1
+          fi
+
+          if ! gh api "repos/${EXOSPHERE_REPO}/commits/${EXOSPHERE_REF}" --jq .sha > /dev/null 2>&1; then
+            gh issue comment "$ISSUE_NUMBER" --body "### Command Results ❌
+
+          \`MORPHOCLOUD_EXOSPHERE_REF\` points to a commit that does not exist in \`${EXOSPHERE_REPO}\`. No instance was created. Please tag @MorphoCloud/morphocloud-admins."
+            echo "::error ::Commit $EXOSPHERE_REF not found in $EXOSPHERE_REPO"
+            exit 1
+          fi
+
+          sed -i "s|^exosphere_sha=.*|exosphere_sha=\"${EXOSPHERE_REF}\" # MORPHOCLOUD_EXOSPHERE_REF (custom course image)|" ./cloud-config
+          if ! grep -q "^exosphere_sha=\"${EXOSPHERE_REF}\"" ./cloud-config; then
+            echo "::error ::Failed to apply MORPHOCLOUD_EXOSPHERE_REF to cloud-config"
+            exit 1
+          fi
+
+          gh issue comment "$ISSUE_NUMBER" --body "🔧 Custom course image: this instance will boot \`${EXOSPHERE_REPO}\` commit \`${EXOSPHERE_REF}\` (from \`MORPHOCLOUD_EXOSPHERE_REF\`)."
+          echo "Applied custom exosphere ref $EXOSPHERE_REF"
+        env:
+          EXOSPHERE_REF: ${{ vars.MORPHOCLOUD_EXOSPHERE_REF || '' }}
+          EXOSPHERE_REPO: MorphoCloud/exosphere
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
 
       - name: Create instance (acquire)
         id: provision

--- a/course-software-customization.md
+++ b/course-software-customization.md
@@ -1,204 +1,94 @@
 # Course Software Customization
 
-This document describes how to provision a course with custom software (e.g.,
-additional packages, Ansible roles, or a different Slicer configuration) that
-differs from the standard MorphoCloud instance.
+How to provision a course with a software suite different from the standard
+SlicerMorph image (extra packages, different Slicer configuration, additional
+Ansible roles).
 
-## Overview
+## How it works
 
-MorphoCloud instances boot using a `cloud-config` that clones a specific commit
-of [MorphoCloud/exosphere](https://github.com/MorphoCloud/exosphere) and runs
-its Ansible playbook. By pointing a course repo's `cloud-config` at a
-course-specific exosphere branch, you can customize the software stack without
-affecting other courses or the standard instance.
+Instances install software at first boot: `cloud-config` clones
+[MorphoCloud/exosphere](https://github.com/MorphoCloud/exosphere) (a plain, full
+clone) and `git reset --hard`s to a pinned commit, then runs the Ansible
+playbook. For a custom course, the customization lives in a `course/<slug>`
+branch of `exosphere`; the course repo's boot path picks it up through a single
+repo **variable** — the committed `cloud-config` stays generic.
 
-**Key principle:** Each course with custom software gets a dedicated branch in
-both `exosphere` and `MorphoCloudWorkflow`. The standard `main` branch remains
-untouched.
+**`MORPHOCLOUD_EXOSPHERE_REF`** (per `MC-*` repo, absent by default):
 
-### How the pieces fit together
+- When unset, `/create` uses the standard vendorized pin — default course,
+  nothing to do.
+- When set, it must be the **full 40-character commit SHA** on
+  `MorphoCloud/exosphere` — normally the HEAD of the course's `course/<slug>`
+  branch. `create-course-instance.yml` validates it (format + the commit exists)
+  **before any OpenStack call**, rewrites the `exosphere_sha` line in the
+  workspace copy of `cloud-config`, and records the applied ref in a comment on
+  the instance issue.
 
-Three repositories are involved:
+A SHA rather than a branch name keeps the course reproducible: students
+provisioned weeks apart boot the same image. A mid-course software update is a
+deliberate act — push to the branch, set the variable to the new SHA; only
+instances created afterward are affected.
 
-1. **`exosphere`** — Contains the Ansible playbook and roles that install
-   software on instances. A course branch here (e.g., `course/ut-geo101`) holds
-   the custom software configuration (different Slicer version, extra
-   extensions, additional packages, etc.).
+Because the variable survives `vendorize-course`, re-vendorizing a course repo
+no longer risks silently resetting its image pin.
 
-2. **`MorphoCloudWorkflow`** — Contains the GitHub Actions workflows and
-   `cloud-config` template. The `cloud-config` has a hardcoded SHA that tells
-   the instance which exosphere commit to clone at boot. A course branch here
-   has only one difference from the parent branch: the `cloud-config` points to
-   the course-specific exosphere commit instead of the standard one. Currently,
-   the active development branch is `implement-workflow-split` (`main` is stale
-   and maintained only for the current production environment).
+## Setting up a custom course
 
-3. **`MC-<COURSE>` (e.g., `MC-UT-GEO101`)** — The course's instance repo. It
-   receives vendorized copies of the workflows and `cloud-config` from
-   MorphoCloudWorkflow. This repo always uses its `main` branch — the course
-   branching happens upstream in the other two repos.
+1. **Branch exosphere** from the current production tag and add the
+   customization:
 
-## Prerequisites
+   ```bash
+   cd ~/Desktop/Projects/MorphoCloudWorkflow
+   pipx run nox -s display-exosphere-version   # the morpho-cloud-portal-… tag
 
-- The course has already been created through the normal intake process (MC-\*
-  repo exists, standard vendorize done)
-- `pipx` is installed (see [MAINTENANCE.md](MAINTENANCE.md))
+   cd ~/Desktop/Projects/exosphere
+   git switch -c course/<slug> <that-tag>
+   # edit ansible/roles + playbook as requested
+   git commit && git push origin course/<slug>
+   ```
 
-## Workflow
+2. **Point the course repo at it:**
 
-### Step 1: Identify the current exosphere branch
+   ```bash
+   gh variable set MORPHOCLOUD_EXOSPHERE_REF \
+     --repo MorphoCloud/MC-<COURSE> \
+     --body "$(git -C ~/Desktop/Projects/exosphere rev-parse course/<slug>)"
+   ```
 
-All MorphoCloud instances use a tagged exosphere branch (e.g.,
-`morpho-cloud-portal-2025.09.17-96cec41fb`). The course branch will be created
-from this same starting point so it inherits the current standard configuration.
+3. Done — the next `/create` in that repo boots the custom image. No vendorize,
+   no MorphoCloudWorkflow branch, no `cloud-config` edit.
 
-```bash
-PROJECTS_DIR=~/Desktop/Projects
-cd $PROJECTS_DIR/MorphoCloudWorkflow
+**Timing rule:** confirm the suite is custom-and-ready (or confirmed default)
+**before** the instructor pushes `students.txt`. Don't enroll students into an
+unconfirmed image.
 
-pipx run nox -s display-exosphere-version
-exosphere_branch=$(pipx run nox -s display-exosphere-version 2>&1 | grep -o 'morpho-cloud[^]]*')
-echo $exosphere_branch
-```
+## Validating a new custom image
 
-### Step 2: Create a course branch in exosphere
+- Set the variable to the branch SHA, `/create` on a test issue, and verify the
+  requested software is present in-guest (the issue gets a "Custom course image"
+  comment recording the exact commit).
+- A garbage value fails loudly before any resource is created.
+- Unset the variable (`gh variable delete MORPHOCLOUD_EXOSPHERE_REF --repo …`)
+  to return the course to the standard image.
 
-Clone exosphere and create a branch where you'll make the software changes. The
-branch name should follow the `course/<short-name>` convention.
+## Registry — which courses are customized?
 
-```bash
-cd $PROJECTS_DIR
-
-# Clone exosphere on the current branch
-git clone https://github.com/MorphoCloud/exosphere -b $exosphere_branch
-
-cd exosphere
-
-# Create a course-specific branch
-git switch -c course/ut-geo101
-```
-
-Add custom software. For example, to add a new Ansible role:
+The variable doubles as the registry:
 
 ```bash
-# Edit ansible/roles as needed, e.g.:
-# - Add a new role in ansible/roles/custom-package/
-# - Add the role to the playbook
-# - Modify existing role variables
-
-git add {new files}
-git commit -m "feat: Add custom packages for UT GEO101"
-git push origin course/ut-geo101
+for r in $(gh repo list MorphoCloud --json name --jq '.[].name | select(startswith("MC-"))'); do
+  echo -n "$r: "
+  gh variable get MORPHOCLOUD_EXOSPHERE_REF --repo "MorphoCloud/$r" 2>/dev/null || echo "(standard)"
+done
 ```
 
-### Step 3: Create a matching branch in MorphoCloudWorkflow
+## Branch lifetime
 
-This branch will be identical to the current development branch except for the
-exosphere SHA in `cloud-config`. Using the same `course/*` branch name makes it
-easy to see which courses have custom software.
-
-```bash
-cd $PROJECTS_DIR/MorphoCloudWorkflow
-git switch -c course/ut-geo101
-```
-
-### Step 4: Bump exosphere to the course branch
-
-```bash
-pipx run nox -s bump-exosphere -- $PROJECTS_DIR/exosphere --commit
-```
-
-This updates `cloud-config`'s `exosphere_sha=` line to point to the course
-branch's HEAD commit. The change is committed on the `course/ut-geo101` branch —
-`main` is untouched.
-
-### Step 5: Vendorize to the course repo
-
-Copy the workflows and the course-specific `cloud-config` into the MC-\* repo.
-From this point on, any instance created from MC-UT-GEO101 will boot with the
-custom software.
-
-```bash
-pipx run nox -s vendorize -- $PROJECTS_DIR/MC-UT-GEO101/ --commit
-
-cd $PROJECTS_DIR/MC-UT-GEO101
-git push origin main
-```
-
-### Step 6: Switch back to the parent branch
-
-Return to the parent branch so that future work (vendorizing other courses,
-making workflow improvements) starts from the standard branch.
-
-```bash
-cd $PROJECTS_DIR/MorphoCloudWorkflow
-git switch implement-workflow-split
-```
-
-## Re-vendorizing After Workflow Updates
-
-When `MorphoCloudWorkflow` receives fixes or improvements (bug fixes, new
-workflow features, etc.) that should be propagated to a course with custom
-software, merge the parent branch into the course branch. The parent branch is
-whichever branch the course branch was created from (e.g.,
-`implement-workflow-split`).
-
-```bash
-cd $PROJECTS_DIR/MorphoCloudWorkflow
-
-# Switch to the course branch and merge the parent branch
-git switch course/ut-geo101
-git merge implement-workflow-split
-
-# Vendorize the merged result to the course repo
-pipx run nox -s vendorize -- $PROJECTS_DIR/MC-UT-GEO101/ --commit
-
-cd $PROJECTS_DIR/MC-UT-GEO101
-git push origin main
-
-# Switch back
-cd $PROJECTS_DIR/MorphoCloudWorkflow
-git switch implement-workflow-split
-```
-
-**Why merge the parent branch into the course branch?** The course branch's only
-difference from its parent is the exosphere SHA in `cloud-config`. Merging the
-parent branch brings in all the workflow fixes and improvements while preserving
-that custom SHA. The result is a branch that has both the latest workflows _and_
-the course-specific software configuration. This merged branch is what gets
-vendorized into the MC-\* repo.
-
-If there are merge conflicts (unlikely — they would only occur if the parent
-branch also changed the exosphere SHA line), resolve them by keeping the course
-branch's SHA.
-
-## Re-vendorizing After Exosphere Updates
-
-When the course-specific exosphere branch receives new commits (e.g., the
-instructor requests an additional Slicer extension or a package version bump):
-
-```bash
-cd $PROJECTS_DIR/MorphoCloudWorkflow
-git switch course/ut-geo101
-
-# Bump to the latest exosphere commit on the course branch
-pipx run nox -s bump-exosphere -- $PROJECTS_DIR/exosphere --commit
-
-# Vendorize
-pipx run nox -s vendorize -- $PROJECTS_DIR/MC-UT-GEO101/ --commit
-
-cd $PROJECTS_DIR/MC-UT-GEO101
-git push origin main
-
-cd $PROJECTS_DIR/MorphoCloudWorkflow
-git switch implement-workflow-split
-```
-
-## Notes
-
-- The `course/*` branch naming convention in both repos makes it easy to
-  identify which branches exist for custom courses
-- Standard courses (no custom software) continue to be vendorized from `main` as
-  usual — this workflow does not affect them
-- When a course ends and is archived, the `course/*` branches in both
-  `exosphere` and `MorphoCloudWorkflow` can be deleted
+- **While the course is live, the `course/<slug>` branch must stay pushed.** A
+  commit reachable only from a deleted branch is eventually garbage-collected on
+  GitHub, and the boot clone would no longer contain it.
+- When the course ends, delete the variable and the branch.
+- A course branch is a point-in-time fork: it does **not** receive later
+  production fixes (OS/security/Slicer). If a branch is reused across terms,
+  rebase it onto the current production tag between terms, re-validate, and set
+  the variable to the new HEAD.


### PR DESCRIPTION
Applies the M3/M7 authorize-execute split, course-team membership gate, commenter-keyed quota bypass, and permissions block to create-course-instance.yml, and implements the MORPHOCLOUD_EXOSPHERE_REF provision-time custom image flow per #194 (course-software-customization.md rewritten accordingly).

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)