### PR TITLE
feat: Course lookups move to POST with server-side roster resolution

### DIFF
--- a/.github/actions/control-instance/action.yml
+++ b/.github/actions/control-instance/action.yml
@@ -48,10 +48,9 @@ inputs:
       "GitHub username of the issue creator (used for email lookup on unshelve)"
     required: false
     default: ""
-  roster_sheet_id:
+  course_team_slug:
     description:
-      "Google Sheet ID of the instructor-owned course roster (course repos only;
-      leave blank for individual repos)"
+      "Course team slug (course repos only; leave blank for individual repos)"
     required: false
     default: ""
 runs:
@@ -627,7 +626,7 @@ runs:
       id: send_email_individual
       if:
         ${{ steps.check_instance.outputs.exists == 'true' && success() &&
-        inputs.command_name == 'unshelve' && inputs.roster_sheet_id == '' }}
+        inputs.command_name == 'unshelve' && inputs.course_team_slug == '' }}
       uses: ./.github/actions/send-email
       with:
         os_cloud: ${{ inputs.os_cloud }}
@@ -644,7 +643,7 @@ runs:
       id: send_email_course
       if:
         ${{ steps.check_instance.outputs.exists == 'true' && success() &&
-        inputs.command_name == 'unshelve' && inputs.roster_sheet_id != '' }}
+        inputs.command_name == 'unshelve' && inputs.course_team_slug != '' }}
       uses: ./.github/actions/course-send-email
       with:
         os_cloud: ${{ inputs.os_cloud }}
@@ -652,7 +651,7 @@ runs:
         email_lookup_url: ${{ inputs.email_lookup_url }}
         email_lookup_secret: ${{ inputs.email_lookup_secret }}
         issue_creator: ${{ inputs.issue_creator }}
-        roster_sheet_id: ${{ inputs.roster_sheet_id }}
+        course_team_slug: ${{ inputs.course_team_slug }}
         mail_server_username: ${{ inputs.mail_server_username }}
         mail_server_password: ${{ inputs.mail_server_password }}
         instance_name: ${{ steps.define.outputs.instance_name }}

--- a/.github/actions/course-send-email/action.yml
+++ b/.github/actions/course-send-email/action.yml
@@ -34,10 +34,10 @@ inputs:
       required by its lookup endpoints"
     required: false
     default: ""
-  roster_sheet_id:
+  course_team_slug:
     description:
-      "Google Sheet ID of the instructor-owned course roster shared with
-      morphocloudportal@gmail.com"
+      "Course team slug (mc-…); the roster sheet is resolved server-side by the
+      Apps Script endpoint"
     required: true
   issue_creator:
     description: "GitHub username of the course student (issue creator)"
@@ -80,7 +80,7 @@ runs:
       with:
         lookup_url: ${{ inputs.email_lookup_url }}
         github_username: ${{ inputs.issue_creator }}
-        roster_sheet_id: ${{ inputs.roster_sheet_id }}
+        course_team_slug: ${{ inputs.course_team_slug }}
         gas_secret: ${{ inputs.email_lookup_secret }}
 
     - name: Generate Guacamole Connection URL

--- a/.github/actions/lookup-email/action.yml
+++ b/.github/actions/lookup-email/action.yml
@@ -12,10 +12,11 @@ inputs:
   github_username:
     description: "GitHub username to look up"
     required: true
-  roster_sheet_id:
+  course_team_slug:
     description:
-      "Google Sheet ID of the instructor-owned course roster (when set, uses
-      lookup_course_roster instead of lookup)"
+      "Course team slug (mc-…). When set and lookup_url is an Apps Script
+      endpoint, uses lookup_course_roster — the roster sheet is resolved
+      server-side from the approved course, never named by the caller."
   api_key:
     description:
       "Optional API key sent as X-Api-Key header. Required when lookup_url
@@ -26,8 +27,8 @@ inputs:
     description:
       "Shared secret for the Apps Script web app (ENROLLMENT_WEBHOOK_SECRET).
       Required when lookup_url is the course-intake script.google.com URL — its
-      lookup actions reject unauthenticated calls. Sent as a query parameter
-      because Apps Script cannot read request headers; only ever appended to
+      lookup actions reject unauthenticated calls. Sent in a POST JSON body
+      (Apps Script cannot read request headers); only ever sent to
       script.google.com URLs."
     required: false
     default: ""
@@ -44,31 +45,28 @@ runs:
       run: |
         echo "Looking up email for GitHub user '$GITHUB_USERNAME'"
 
-        ENCODED_USERNAME=$(python3 -c "import urllib.parse, os; print(urllib.parse.quote(os.environ['GITHUB_USERNAME']))")
-
-        # Extract sheet ID if a full Google Sheets URL was pasted instead of just the ID
-        if [[ "$ROSTER_SHEET_ID" =~ /spreadsheets/d/([a-zA-Z0-9_-]+) ]]; then
-          ROSTER_SHEET_ID="${BASH_REMATCH[1]}"
-          echo "Extracted sheet ID from URL: ${ROSTER_SHEET_ID}"
-        fi
-
         CURL_ARGS=(-sL --retry 3 --retry-delay 5 --retry-all-errors)
         if [[ -n "$API_KEY" ]]; then
           CURL_ARGS+=(-H "X-Api-Key: $API_KEY")
         fi
 
-        # Apps Script cannot read headers, so its shared secret travels as a
-        # query parameter — but never to non-Apps-Script endpoints.
-        SECRET_PARAM=""
-        if [[ -n "$GAS_SECRET" && "$LOOKUP_URL" == *script.google.com* ]]; then
-          SECRET_PARAM="&secret=$(python3 -c "import urllib.parse, os; print(urllib.parse.quote(os.environ['GAS_SECRET']))")"
-        fi
-
-        if [[ -n "$ROSTER_SHEET_ID" ]]; then
-          ENCODED_SHEET_ID=$(python3 -c "import urllib.parse, os; print(urllib.parse.quote(os.environ['ROSTER_SHEET_ID']))")
-          RESPONSE=$(curl "${CURL_ARGS[@]}" "${LOOKUP_URL}?action=lookup_course_roster&sheet_id=${ENCODED_SHEET_ID}&github_username=${ENCODED_USERNAME}${SECRET_PARAM}")
+        if [[ "$LOOKUP_URL" == *script.google.com* ]]; then
+          # Apps Script: privileged lookups are POST-only; the shared secret
+          # travels in the JSON body, never the URL. The roster lookup is
+          # keyed by team slug — the sheet is resolved server-side.
+          if [[ -n "$COURSE_TEAM_SLUG" ]]; then
+            PAYLOAD=$(jq -n --arg a lookup_course_roster --arg t "$COURSE_TEAM_SLUG" \
+              --arg u "$GITHUB_USERNAME" --arg s "$GAS_SECRET" \
+              '{action:$a, team_slug:$t, github_username:$u, secret:$s}')
+          else
+            PAYLOAD=$(jq -n --arg a lookup --arg u "$GITHUB_USERNAME" --arg s "$GAS_SECRET" \
+              '{action:$a, github_username:$u, secret:$s}')
+          fi
+          RESPONSE=$(curl "${CURL_ARGS[@]}" -X POST -H "Content-Type: application/json" \
+            --data "$PAYLOAD" "$LOOKUP_URL")
         else
-          RESPONSE=$(curl "${CURL_ARGS[@]}" "${LOOKUP_URL}?action=lookup&github_username=${ENCODED_USERNAME}${SECRET_PARAM}")
+          ENCODED_USERNAME=$(python3 -c "import urllib.parse, os; print(urllib.parse.quote(os.environ['GITHUB_USERNAME']))")
+          RESPONSE=$(curl "${CURL_ARGS[@]}" "${LOOKUP_URL}?action=lookup&github_username=${ENCODED_USERNAME}")
         fi
 
         EMAIL=$(echo "$RESPONSE" | jq -r '.email // empty')
@@ -85,6 +83,6 @@ runs:
       env:
         LOOKUP_URL: ${{ inputs.lookup_url }}
         GITHUB_USERNAME: ${{ inputs.github_username }}
-        ROSTER_SHEET_ID: ${{ inputs.roster_sheet_id }}
+        COURSE_TEAM_SLUG: ${{ inputs.course_team_slug }}
         API_KEY: ${{ inputs.api_key }}
         GAS_SECRET: ${{ inputs.gas_secret }}

--- a/.github/workflows/control-instance-from-workflow.yml
+++ b/.github/workflows/control-instance-from-workflow.yml
@@ -21,10 +21,8 @@ on:
         required: false
         type: string
         default: ""
-      roster_sheet_id:
-        description:
-          "Google Sheet ID of the course roster (leave blank for individual
-          repos)"
+      course_team_slug:
+        description: "Course team slug (leave blank for individual repos)"
         required: false
         type: string
         default: ""
@@ -48,10 +46,8 @@ on:
         required: false
         type: string
         default: ""
-      roster_sheet_id:
-        description:
-          "Google Sheet ID of the course roster (leave blank for individual
-          repos)"
+      course_team_slug:
+        description: "Course team slug (leave blank for individual repos)"
         required: false
         type: string
         default: ""
@@ -79,6 +75,6 @@ jobs:
           email_lookup_api_key: ${{ secrets.MORPHOCLOUD_LOOKUP_API_KEY }}
           email_lookup_secret: ${{ secrets.ENROLLMENT_WEBHOOK_SECRET }}
           issue_creator: ${{ inputs.issue_creator }}
-          roster_sheet_id: ${{ inputs.roster_sheet_id }}
+          course_team_slug: ${{ inputs.course_team_slug }}
           mail_server_username: ${{secrets.MAIL_USERNAME}}
           mail_server_password: ${{secrets.MAIL_PASSWORD}}

--- a/.github/workflows/control-instance.yml
+++ b/.github/workflows/control-instance.yml
@@ -136,6 +136,6 @@ jobs:
           email_lookup_api_key: ${{ secrets.MORPHOCLOUD_LOOKUP_API_KEY }}
           email_lookup_secret: ${{ secrets.ENROLLMENT_WEBHOOK_SECRET }}
           issue_creator: ${{ github.event.issue.user.login }}
-          roster_sheet_id: ${{ vars.MORPHOCLOUD_STUDENT_ROSTER_SHEET_ID }}
+          course_team_slug: ${{ vars.COURSE_TEAM_SLUG }}
           mail_server_username: ${{secrets.MAIL_USERNAME}}
           mail_server_password: ${{secrets.MAIL_PASSWORD}}

--- a/.github/workflows/create-course-instance.yml
+++ b/.github/workflows/create-course-instance.yml
@@ -353,7 +353,7 @@ jobs:
           mail_server_password: ${{ secrets.MAIL_PASSWORD }}
           instance_name: ${{ steps.provision.outputs.instance_name }}
           instance_issue_number: ${{ github.event.issue.number }}
-          roster_sheet_id: ${{ vars.MORPHOCLOUD_STUDENT_ROSTER_SHEET_ID }}
+          course_team_slug: ${{ vars.COURSE_TEAM_SLUG }}
 
       - name: comment (failed to send email)
         if: ${{ steps.send_email.outcome == 'failure' && failure() }}

--- a/.github/workflows/send-email.yml
+++ b/.github/workflows/send-email.yml
@@ -170,7 +170,7 @@ jobs:
           mail_server_password: ${{ secrets.MAIL_PASSWORD }}
           email_lookup_url: ${{ vars.MORPHOCLOUD_EMAIL_LOOKUP_URL }}
           email_lookup_secret: ${{ secrets.ENROLLMENT_WEBHOOK_SECRET }}
-          roster_sheet_id: ${{ vars.MORPHOCLOUD_STUDENT_ROSTER_SHEET_ID }}
+          course_team_slug: ${{ vars.COURSE_TEAM_SLUG }}
           instance_name: ${{ steps.define.outputs.instance_name }}
           instance_issue_number: ${{ github.event.issue.number }}
 


### PR DESCRIPTION
Privileged Apps Script lookups become POST-only (secret in body, not URL) and lookup_course_roster is keyed by team slug with the roster sheet resolved server-side (closes the H3 sheet_id confused-deputy). Caller chain renamed roster_sheet_id → course_team_slug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)