### PR TITLE
fix: Drop -X POST on the Apps Script lookup call

### DIFF
--- a/.github/actions/lookup-email/action.yml
+++ b/.github/actions/lookup-email/action.yml
@@ -62,8 +62,11 @@ runs:
             PAYLOAD=$(jq -n --arg a lookup --arg u "$GITHUB_USERNAME" --arg s "$GAS_SECRET" \
               '{action:$a, github_username:$u, secret:$s}')
           fi
-          RESPONSE=$(curl "${CURL_ARGS[@]}" -X POST -H "Content-Type: application/json" \
-            --data "$PAYLOAD" "$LOOKUP_URL")
+          # -d without -X POST: Apps Script answers with a 302 to
+          # googleusercontent; curl must switch to GET on the redirect
+          # (an explicit -X POST forces POST there and returns HTML).
+          RESPONSE=$(curl "${CURL_ARGS[@]}" -H "Content-Type: application/json" \
+            -d "$PAYLOAD" "$LOOKUP_URL")
         else
           ENCODED_USERNAME=$(python3 -c "import urllib.parse, os; print(urllib.parse.quote(os.environ['GITHUB_USERNAME']))")
           RESPONSE=$(curl "${CURL_ARGS[@]}" "${LOOKUP_URL}?action=lookup&github_username=${ENCODED_USERNAME}")


### PR DESCRIPTION
Apps Script replies 302 to script.googleusercontent.com; curl must
switch to GET on that redirect. An explicit -X POST forces POST on the
redirected request and returns Google's HTML instead of the JSON body
(same recipe enroll-students.yml already uses).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
