### PR TITLE
feat: Credential email copy moves to MorphoCloudPortalContent

### DIFF
--- a/.github/actions/send-email/action.yml
+++ b/.github/actions/send-email/action.yml
@@ -61,6 +61,27 @@ runs:
       with:
         instance_ip: ${{ steps.instance_metadata.outputs.instance_ip }}
 
+    # Email copy lives in MorphoCloudPortalContent (instance-credentials.json),
+    # fetched at send time — copy edits go live on the next /create or /email
+    # with no vendorize. render.py substitutes the placeholders (plain string
+    # replace, safe for URLs and passphrases).
+    - name: Fetch and render email template
+      id: render
+      shell: bash
+      run: |
+        curl -sfL --retry 3 --retry-delay 5 --retry-all-errors \
+          -o /tmp/instance-credentials.json "$TEMPLATE_URL"
+        python3 "$GITHUB_ACTION_PATH/render.py" /tmp/instance-credentials.json
+      env:
+        TEMPLATE_URL: https://raw.githubusercontent.com/MorphoCloud/MorphoCloudPortalContent/main/templates/instance-credentials.json
+        REPO_NAME: ${{ github.event.repository.name }}
+        REPOSITORY: ${{ github.repository }}
+        ISSUE_NUMBER: ${{ inputs.instance_issue_number }}
+        INSTANCE_NAME: ${{ inputs.instance_name }}
+        INSTANCE_IP: ${{ steps.instance_metadata.outputs.instance_ip }}
+        CONNECTION_URL: ${{ steps.guacamole.outputs.connection_url }}
+        PASSPHRASE: ${{ steps.instance_metadata.outputs.instance_pwd }}
+
     - name: Send mail
       uses: dawidd6/action-send-mail@42942bc2f8fba4e611b459a018967a6a7c78c68c # v17
       with:
@@ -71,60 +92,9 @@ runs:
         password: ${{ inputs.mail_server_password }}
         from: MorphoCloudPortal <no-reply@morphocloud.org>
         to: ${{ steps.lookup_email.outputs.email }}
-        subject:
-          "[${{ github.event.repository.name }}] Instance ${{
-          inputs.instance_name }} active"
+        subject: ${{ steps.render.outputs.subject }}
         convert_markdown: true
-        html_body: |
-          Your MorphoCloud instance is up and running:
-
-          * **Graphical User Interface (GUI)**: Use the URL provided to connect from a web browser. For improved performance and responsiveness, you may also use a dedicated TurboVNC client.
-          * **Command Line Access**: Use the SSH information provided below to access your instance
-          from the command line.
-
-          In both cases, username is **exouser** and the passphrase is provided.
-
-          **Important Notes:**
-
-          - Each session is limited to 4 hours. **Without explicit action, your instance will be automatically shelved after this time.** Around 3h30m into your session,
-            a popup will appear in the graphical interface asking whether you'd like to extend your session — clicking "Yes" will delay shelving by another 4 hours.
-            Alternatively, you can extend the session at any time before the timeout by clicking the **"ExtendInstanceSession" icon on the desktop**.
-            If no action is taken, the instance will be shelved and all GUI or SSH connections will be disconnected. Your data will be preserved and the instance can
-            later be unshelved.
-          - To create an instance, use the `/create` command.
-          - To unshelve an existing instance, use the `/unshelve` command.
-          - To shelve an instance and preserve your allocation, use the `/shelve` command.
-          - To obtain the latest set of access credentials, use the `/email` command.
-          - To delete an instance and/or its volume, use the `/delete_instance`, `/delete_volume`, or `/delete_all` commands.
-          - Commands should be added as comments to issue [${{ github.repository }}#${{ inputs.instance_issue_number }}](https://github.com/${{ github.repository }}/issues/${{ inputs.instance_issue_number }})
-
-          If you have questions, please contact [portal@morphocloud.org](mailto:portal@morphocloud.org).
-
-          **Connection Methods:**
-
-          - TurboVNC: `${{ steps.instance_metadata.outputs.instance_ip }}:1`
-          - Web connect: [${{ steps.guacamole.outputs.connection_url }}](${{ steps.guacamole.outputs.connection_url }})
-          - SSH: `ssh exouser@${{ steps.instance_metadata.outputs.instance_ip }}`
-
-          **Credentials:**
-
-          - Username: **exouser**
-          - Passphrase: `${{ steps.instance_metadata.outputs.instance_pwd }}`
-
-          **Supported Issue Commands:**
-
-          _The commands listed below may be added as comments to issue [${{ github.repository }}#${{ inputs.instance_issue_number }}](https://github.com/${{ github.repository }}/issues/${{ inputs.instance_issue_number }}). Only one command
-          may be entered per comment._
-
-          - `/create`: Create **${{ inputs.instance_name }}**
-          - `/shelve`: Shelve **${{ inputs.instance_name }}**
-          - `/unshelve`: Unshelve **${{ inputs.instance_name }}**
-          - `/email`: Send this email with connection URL
-          - `/renew`: Extend the instance lifespan if additional time is available.
-          - `/delete_instance`: Delete **${{ inputs.instance_name }}**
-          - `/delete_volume`: Delete volume associated with **${{ inputs.instance_name }}**
-          - `/delete_all`: Delete both **${{ inputs.instance_name }}** and associated volume
-
+        html_body: ${{ steps.render.outputs.body }}
     - name: Set error message
       id: set_error_message
       if: ${{ failure() }}
@@ -134,9 +104,12 @@ runs:
           error_message="Failed to retrieve metadata"
         elif [[ $GUACAMOLE_OUTCOME == "failure" ]]; then
           error_message="Failed to generate connection URL"
+        elif [[ $RENDER_OUTCOME == "failure" ]]; then
+          error_message="Failed to fetch or render the email template"
         fi
         echo "error_message=$error_message" >> $GITHUB_OUTPUT
       env:
         # Step outcome
         INSTANCE_METADATA_OUTCOME: ${{ steps.instance_metadata.outcome }}
         GUACAMOLE_OUTCOME: ${{ steps.guacamole.outcome }}
+        RENDER_OUTCOME: ${{ steps.render.outcome }}

--- a/.github/actions/send-email/render.py
+++ b/.github/actions/send-email/render.py
@@ -1,0 +1,40 @@
+"""Render the instance-credentials email from the PortalContent template.
+
+Reads the fetched JSON (argv[1]) and the placeholder values from the
+environment, then appends the rendered subject/body to $GITHUB_OUTPUT.
+Plain str.replace — no regex/sed — so passphrases, URLs with &/# and
+markdown all pass through untouched.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+t = json.loads(Path(sys.argv[1]).read_text())
+
+subs = {
+    "{{repo_name}}": os.environ["REPO_NAME"],
+    "{{repository}}": os.environ["REPOSITORY"],
+    "{{issue_number}}": os.environ["ISSUE_NUMBER"],
+    "{{instance_name}}": os.environ["INSTANCE_NAME"],
+    "{{instance_ip}}": os.environ["INSTANCE_IP"],
+    "{{connection_url}}": os.environ["CONNECTION_URL"],
+    "{{passphrase}}": os.environ["PASSPHRASE"],
+    "{{contact_email}}": t["contact_email"],
+}
+
+
+def render(text: str) -> str:
+    for key, value in subs.items():
+        text = text.replace(key, value)
+    return text
+
+
+with Path(os.environ["GITHUB_OUTPUT"]).open("a") as out:
+    out.write("subject<<__RENDER_EOF__\n")
+    out.write(render(t["credentials_subject"]) + "\n")
+    out.write("__RENDER_EOF__\n")
+    out.write("body<<__RENDER_EOF__\n")
+    out.write(render(t["credentials_body"]) + "\n")
+    out.write("__RENDER_EOF__\n")


### PR DESCRIPTION
send-email fetches templates/instance-credentials.json at send time and
renders it via render.py (plain string replace — safe for passphrases
and URLs with &/#). Copy edits in PortalContent go live on the next
/create or /email with no vendorize.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
