### PR TITLE
fix: Restore quote dropped in #212 — cron was syntax-broken

### DIFF
--- a/.github/workflows/automatic-instance-deleting.yml
+++ b/.github/workflows/automatic-instance-deleting.yml
@@ -241,7 +241,7 @@ jobs:
                       renew_hint='No renewals remain.'
                     fi
                     gh issue comment "$issue_number" \
-                      --body '⚠️ Instance and volume will be deleted in '"$days_until_expiration"' days. '"$renew_hint
+                      --body '⚠️ Instance and volume will be deleted in '"$days_until_expiration"' days. '"$renew_hint"
                     set +e
                     gh workflow run send-renewal-email.yml \
                       -f issue_number=$issue_number \


### PR DESCRIPTION
The renewal-aware warning edit left the gh issue comment --body
unterminated (line 244), so every automatic-instance-deleting run
failed with 'unexpected EOF while looking for matching quote'. All run
blocks now verified with bash -n.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
