### PR TITLE
feat: students.txt -> roster-handles.txt; clearer not-in-roster error

### DIFF
--- a/.github/actions/course-send-email/action.yml
+++ b/.github/actions/course-send-email/action.yml
@@ -146,7 +146,7 @@ runs:
         if [[ $INSTANCE_METADATA_OUTCOME == "failure" ]]; then
           error_message="Failed to retrieve metadata"
         elif [[ $LOOKUP_EMAIL_OUTCOME == "failure" ]]; then
-          error_message="Failed to look up email address for course student"
+          error_message="**@${ISSUE_CREATOR}'s GitHub handle was not found in the course roster.** Ask your instructor to add your handle and email to the roster (Google Sheet), then comment \`/email\` here to receive your credentials."
         elif [[ $GUACAMOLE_OUTCOME == "failure" ]]; then
           error_message="Failed to generate connection URL"
         else
@@ -154,6 +154,7 @@ runs:
         fi
         echo "error_message=$error_message" >> $GITHUB_OUTPUT
       env:
+        ISSUE_CREATOR: ${{ inputs.issue_creator }}
         INSTANCE_METADATA_OUTCOME: ${{ steps.instance_metadata.outcome }}
         LOOKUP_EMAIL_OUTCOME: ${{ steps.lookup_email.outcome }}
         GUACAMOLE_OUTCOME: ${{ steps.guacamole.outcome }}

--- a/.github/workflows/enroll-students.yml
+++ b/.github/workflows/enroll-students.yml
@@ -3,8 +3,8 @@
 # =============================================================================
 #
 # Triggered by:
-#   - Push to students.txt on main (automatic enrollment on file update)
-#   - Manual workflow_dispatch (with usernames input or students.txt fallback)
+#   - Push to roster-handles.txt on main (automatic enrollment on file update)
+#   - Manual workflow_dispatch (with usernames input or roster-handles.txt fallback)
 #
 # What it does for each username:
 #   1. Verifies the GitHub user exists
@@ -37,13 +37,13 @@ name: Enroll Students
 on:
   push:
     branches: [main]
-    paths: [students.txt]
+    paths: [roster-handles.txt]
   workflow_dispatch:
     inputs:
       usernames:
         description:
           "Comma-separated GitHub usernames to enroll (e.g. st1,st2,st3). If
-          blank, falls back to students.txt."
+          blank, falls back to roster-handles.txt."
         required: false
         type: string
         default: ""
@@ -84,13 +84,13 @@ jobs:
             echo "::error::ENROLLMENT_WEBHOOK_SECRET repo secret is not set — the enrollment endpoint requires it."
             exit 1
           fi
-          # Build username list from input or students.txt
+          # Build username list from input or roster-handles.txt
           if [[ -n "$USERNAMES_INPUT" ]]; then
             mapfile -t USERNAMES < <(echo "$USERNAMES_INPUT" | tr ',' '\n' | tr -d ' \r' | grep -v '^$')
-          elif [[ -f students.txt ]]; then
-            mapfile -t USERNAMES < <(grep -v '^\s*#' students.txt | grep -v '^\s*$' | tr -d ' \r')
+          elif [[ -f roster-handles.txt ]]; then
+            mapfile -t USERNAMES < <(grep -v '^\s*#' roster-handles.txt | grep -v '^\s*$' | tr -d ' \r')
           else
-            echo "No usernames provided and students.txt not found — nothing to do."
+            echo "No usernames provided and roster-handles.txt not found — nothing to do."
             exit 0
           fi
 

--- a/course-software-customization.md
+++ b/course-software-customization.md
@@ -59,8 +59,8 @@ no longer risks silently resetting its image pin.
    no MorphoCloudWorkflow branch, no `cloud-config` edit.
 
 **Timing rule:** confirm the suite is custom-and-ready (or confirmed default)
-**before** the instructor pushes `students.txt`. Don't enroll students into an
-unconfirmed image.
+**before** the instructor pushes `roster-handles.txt`. Don't enroll students
+into an unconfirmed image.
 
 ## Validating a new custom image
 

--- a/roster-handles.txt
+++ b/roster-handles.txt
@@ -1,4 +1,7 @@
-# students.txt — Course enrollment list for MC-* repos
+# roster-handles.txt — GitHub handles from the course roster, used for enrollment
+#
+# Paste the github_handle column of your course roster (Google Sheet) here —
+# the two must stay in sync; the roster supplies the matching emails.
 #
 # Add one GitHub username per line.
 # Lines starting with # and blank lines are ignored.


### PR DESCRIPTION
The enrollment file and the roster sheet are one workflow but carried
unrelated names; the filename now states both the linkage and the
content (the roster's github_handle column). The course email-lookup
failure comment now names the actual problem (handle not in the
roster) and the self-service fix (/email after the instructor adds it).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
