### PR TITLE
feat: Tester-feedback quick wins in the command UX

### DIFF
--- a/.github/workflows/on-instance-request-opened.yml
+++ b/.github/workflows/on-instance-request-opened.yml
@@ -135,7 +135,14 @@ jobs:
           MAX_PER_USER: ${{ vars.MORPHOCLOUD_MAX_INSTANCES_PER_USER }}
 
   call-validate-request:
-    needs: [check-instance-team-membership, check-instance-quota]
+    # initial-comments first so the "you may now use /create" go-signal is the
+    # LAST thing the user reads, after the command list (tester feedback)
+    needs:
+      [
+        check-instance-team-membership,
+        check-instance-quota,
+        call-request-initial-comments,
+      ]
     if:
       ${{ contains(github.event.issue.labels.*.name, 'request-type:instance') &&
       contains(github.event.issue.labels.*.name, 'request-creator:user') }}

--- a/course-issue-commands.md
+++ b/course-issue-commands.md
@@ -1,12 +1,13 @@
 ### Supported Issue Commands
 
-_The commands described below may be added as issue comments. Only one command
-may be entered per comment._
+_Type a command below as a comment and press the green **Comment** button to
+submit it — pressing Enter only adds a new line. Only one command may be entered
+per comment._
 
 | Command            | Description                                        | Who                  |
 | ------------------ | -------------------------------------------------- | -------------------- |
-| `/shelve`          | Shelve the instance.                               | Issue creator, Admin |
-| `/unshelve`        | Unshelve the instance.                             | Issue creator, Admin |
+| `/shelve`          | Shelve (shut down) the instance.                   | Issue creator, Admin |
+| `/unshelve`        | Unshelve (restart) the instance.                   | Issue creator, Admin |
 | `/email`           | Send email to _Issue creator_ with connection URL. | Issue creator, Admin |
 | `/create`          | Create the instance and associated volume.         | Issue creator, Admin |
 | `/delete_instance` | Delete the instance.                               | Issue creator, Admin |

--- a/issue-commands.md
+++ b/issue-commands.md
@@ -1,15 +1,16 @@
 ### Supported Issue Commands
 
-_The commands described below may be added as issue comments. Only one command
-may be entered per comment._
+_Type a command below as a comment and press the green **Comment** button to
+submit it — pressing Enter only adds a new line. Only one command may be entered
+per comment._
 
-| Command            | Description                                                   | Who                  |
-| ------------------ | ------------------------------------------------------------- | -------------------- |
-| `/shelve`          | Shelve the instance.                                          | Issue creator, Admin |
-| `/unshelve`        | Unshelve the instance.                                        | Issue creator, Admin |
-| `/email`           | Send email to _Issue creator_ with connection URL.            | Issue creator, Admin |
-| `/renew`           | Extend the instance lifespan if additional time is available. | Issue creator, Admin |
-| `/create`          | Create the instance and associated volume.                    | Issue creator, Admin |
-| `/delete_instance` | Delete the instance.                                          | Issue creator, Admin |
-| `/delete_volume`   | Delete the volume.                                            | Issue creator, Admin |
-| `/delete_all`      | Delete the instance and volume.                               | Issue creator, Admin |
+| Command            | Description                                                          | Who                  |
+| ------------------ | -------------------------------------------------------------------- | -------------------- |
+| `/shelve`          | Shelve (shut down) the instance.                                     | Issue creator, Admin |
+| `/unshelve`        | Unshelve (restart) the instance.                                     | Issue creator, Admin |
+| `/email`           | Send email to _Issue creator_ with connection URL.                   | Issue creator, Admin |
+| `/renew`           | Extend the instance lifespan by an additional 60 days, if available. | Issue creator, Admin |
+| `/create`          | Create the instance and associated volume.                           | Issue creator, Admin |
+| `/delete_instance` | Delete the instance.                                                 | Issue creator, Admin |
+| `/delete_volume`   | Delete the volume.                                                   | Issue creator, Admin |
+| `/delete_all`      | Delete the instance and volume.                                      | Issue creator, Admin |

--- a/workshop-issue-commands.md
+++ b/workshop-issue-commands.md
@@ -1,7 +1,8 @@
 ### Supported Issue Commands
 
-_The commands described below may be added as issue comments. Only one command
-may be entered per comment._
+_Type a command below as a comment and press the green **Comment** button to
+submit it — pressing Enter only adds a new line. Only one command may be entered
+per comment._
 
 | Command      | Description                                               | Who                  |
 | ------------ | --------------------------------------------------------- | -------------------- |


### PR DESCRIPTION
- command lists: shelve (shut down) / unshelve (restart) glosses,
  /renew states the additional 60 days, and the intro says to press the
  green Comment button (Enter only adds a newline)
- the validation 'you may now use /create' comment now waits for the
  commands list, so the go-signal is the last thing the user reads

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
