### PR TITLE
feat: Tester-feedback batch 1 — forms note the Create vs /create split

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-individual-instance-request.yml
+++ b/.github/ISSUE_TEMPLATE/01-individual-instance-request.yml
@@ -37,3 +37,9 @@ body:
         models"._
     validations:
       required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        > **Note:** the **Create** button below only opens your request — your instance is not built yet.
+        > On the page that opens, type `/create` in the comment box and press the green **Comment** button to build it.

--- a/.github/ISSUE_TEMPLATE/02-course-instance-request.yml
+++ b/.github/ISSUE_TEMPLATE/02-course-instance-request.yml
@@ -21,3 +21,9 @@ body:
             I am enrolled in this course and I am requesting a cloud computing
             instance.
           required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        > **Note:** the **Create** button below only opens your request — your instance is not built yet.
+        > On the page that opens, type `/create` in the comment box and press the green **Comment** button to build it.


### PR DESCRIPTION
Re-lands the command-UX copy (#219) and adds a note at the bottom of
the request forms: Create only opens the request; /create builds the
instance.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
