### PR TITLE
feat: status:building until setup completes; drop Description field

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-individual-instance-request.yml
+++ b/.github/ISSUE_TEMPLATE/01-individual-instance-request.yml
@@ -26,18 +26,6 @@ body:
     validations:
       required: true
 
-  - type: textarea
-    attributes:
-      label: Description
-      description:
-        Briefly describe what your project is, your usage needs and how you will
-        be using the instance. E.g., "I am PhD candidate in XYZ University
-        working on 3D morphometrics of fossil bryozoans. I have microCT scans of
-        100s specimens, and would like to use SlicerMorph to segment and extract
-        models"._
-    validations:
-      required: false
-
   - type: markdown
     attributes:
       value: |

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -46,6 +46,7 @@ jobs:
           {"name": "workflow:instances-created", "color": "5319E7", "description": "All workshop instances were created"},
           {"name": "workflow:instances-deleted", "color": "5319E7", "description": "Workshop instances were deleted"},
           {"name": "status:active", "color": "CFD3D7", "description": "The server is active."},
+          {"name": "status:building", "color": "FBCA04", "description": "The server is booting and installing software."},
           {"name": "status:build", "color": "CFD3D7", "description": "The server has not yet finished the original build process."},
           {"name": "status:deleted", "color": "CFD3D7", "description": "The server is deleted."},
           {"name": "status:error", "color": "CFD3D7", "description": "The server is in error."},

--- a/.github/workflows/update-request-status-label.yml
+++ b/.github/workflows/update-request-status-label.yml
@@ -26,13 +26,20 @@ jobs:
           instance_prefix=${PREFIX:+${PREFIX}_}
           instance_basename="${instance_prefix}instance"
 
-          openstack server list --name "^${instance_basename}-\d+" -f json | \
-          jq -r '.[] | [.Name, .Status] | @tsv' | \
-            while IFS=$'\t' read -r instance_name status; do
+          openstack server list --name "^${instance_basename}-\d+" --long -f json | \
+          jq -r '.[] | [.Name, .Status, ((.Properties.exoSetup // "") | tostring)] | @tsv' | \
+            while IFS=$'\t' read -r instance_name status exosetup; do
               issue_number=${instance_name##*-}
               status_lowercase=${status,,}
 
               add_label="status:$status_lowercase"
+
+              # An OpenStack-ACTIVE server is still installing until the
+              # exoSetup marker reports complete — labeling it "active" misled
+              # users into thinking the instance was ready (tester feedback).
+              if [[ "$status" == "ACTIVE" && "$exosetup" != *complete* ]]; then
+                add_label="status:building"
+              fi
 
               remove_labels=$(gh issue view $issue_number --json labels | \
                 jq \


### PR DESCRIPTION
- the status reconciler labeled OpenStack-ACTIVE servers status:active
  while software was still installing; it now checks the exoSetup
  readiness marker and labels the in-between state status:building
- the request form's optional Description field is removed (nothing
  parses it; tester feedback)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
