### PR TITLE
feat: Flavor-based session-timeout overrides (variable-driven)

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -66,6 +66,7 @@ jobs:
           {"name": "status:suspended", "color": "CFD3D7", "description": "The server is suspended, either by request or necessity."},
           {"name": "status:unknown", "color": "CFD3D7", "description": "The state of the server is unknown."},
           {"name": "status:verify_resize", "color": "CFD3D7", "description": "System is awaiting confirmation that the server is operational after a move or resize."},
+          {"name": "timeout:2hrs", "color": "5319E7", "description": "Duration in hours after which the instance will be stopped"},
           {"name": "timeout:4hrs", "color": "5319E7", "description": "Duration in hours after which the instance will be stopped"},
           {"name": "volume:deleted", "color": "0E8CDB", "description": "The volume has been permanently deleted after the grace period."},
           {"name": "volume:expiration-pending", "color": "0E8CDB", "description": "The volume is detached and will be deleted after the grace period."},

--- a/.github/workflows/request-labeler.yml
+++ b/.github/workflows/request-labeler.yml
@@ -62,6 +62,35 @@ jobs:
           NUMBER: ${{ steps.collect_inputs.outputs.issue_number }}
           LABELS: flavor:${{ steps.extract.outputs.instance_flavor }}
 
+      # Flavor-based session-timeout policy. The mapping lives in the repo
+      # variable MORPHOCLOUD_FLAVOR_TIMEOUT_OVERRIDES (e.g.
+      # "g3.xl=2,g4.xl=2,r3.large=2,r3.xl=2"): matching flavors get a
+      # timeout:<N>hrs label, which automatic-instance-shelving already honors
+      # over the repo default. Empty/absent variable = stock behavior —
+      # REVERT by clearing the variable; no code change needed.
+      - name: Add flavor timeout label
+        if:
+          ${{ steps.extract.outputs.instance_flavor != '' &&
+          steps.extract.outputs.instance_flavor != 'null' &&
+          vars.MORPHOCLOUD_FLAVOR_TIMEOUT_OVERRIDES != '' }}
+        run: |
+          IFS=',' read -ra PAIRS <<< "$OVERRIDES"
+          for pair in "${PAIRS[@]}"; do
+            f="$(echo "${pair%%=*}" | xargs)"
+            hrs="$(echo "${pair##*=}" | xargs)"
+            if [[ "$FLAVOR" == "$f" && "$hrs" =~ ^[0-9]+$ ]]; then
+              echo "Flavor $FLAVOR -> timeout:${hrs}hrs (from MORPHOCLOUD_FLAVOR_TIMEOUT_OVERRIDES)"
+              gh issue edit "$NUMBER" --add-label "timeout:${hrs}hrs"
+              break
+            fi
+          done
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ steps.collect_inputs.outputs.issue_number }}
+          FLAVOR: ${{ steps.extract.outputs.instance_flavor }}
+          OVERRIDES: ${{ vars.MORPHOCLOUD_FLAVOR_TIMEOUT_OVERRIDES }}
+
       - name: Add expiration labels
         run: |
           # Check if issue already has an expiration label (e.g., from workshop creation)


### PR DESCRIPTION
High-burn flavors get a shorter shelving timeout via a timeout:<N>hrs
label applied at request-labeling time, driven by the repo variable
MORPHOCLOUD_FLAVOR_TIMEOUT_OVERRIDES (e.g. g3.xl=2,g4.xl=2,...). The
shelving cron already honors timeout labels over the repo default.
Clearing the variable reverts to stock behavior with no code change.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
