### PR TITLE
feat: Guest shelving popup follows the instance's session timeout

### DIFF
--- a/.github/actions/create-instance/action.yml
+++ b/.github/actions/create-instance/action.yml
@@ -15,6 +15,13 @@ inputs:
   volume_name_suffix:
     description: "Volume name suffix"
     required: true
+  default_session_timeout_hrs:
+    description:
+      "Fallback session timeout (hours) for the in-instance shelving popup when
+      the issue has no timeout:<N>hrs label (workflows pass the repo's
+      INSTANCE_SHELVING_TIMEOUT_HRS variable); blank falls back to 4."
+    required: false
+    default: ""
   volume_size_gb:
     description: "Volume size in GB"
     required: false
@@ -244,6 +251,22 @@ runs:
         fi
         sed -i "s|{runner-ssh-public-key}|$(cat "$RUNNER_PUBKEY")|g" ./cloud-config
 
+        # Session timeout for the in-instance shelving popup: highest
+        # timeout:<N>hrs label on the issue, else the repo default, else 4.
+        # Keeps the guest's warning window aligned with the cloud-side
+        # shelving cron, which reads the same label.
+        TIMEOUT_HRS=$(gh issue view "$ISSUE_NUMBER" --json labels \
+          --jq '[.labels[].name | select(test("^timeout:[0-9]+hrs$"))
+                | capture(":(?<n>[0-9]+)hrs$").n | tonumber] | max // empty' || true)
+        if ! [[ "$TIMEOUT_HRS" =~ ^[0-9]+$ ]]; then
+          TIMEOUT_HRS="${DEFAULT_SESSION_TIMEOUT_HRS:-4}"
+        fi
+        if ! [[ "$TIMEOUT_HRS" =~ ^[0-9]+$ ]]; then
+          TIMEOUT_HRS=4
+        fi
+        echo "Session timeout for this instance: ${TIMEOUT_HRS}h"
+        sed -i "s|{session-timeout-hrs}|${TIMEOUT_HRS}|g" ./cloud-config
+
 
         openstack server create "$INSTANCE_NAME" \
           --nic net-id="auto_allocated_network" \
@@ -270,6 +293,10 @@ runs:
         INSTANCE_NAME: ${{ steps.define.outputs.instance_name }}
         INSTANCE_FLAVOR: ${{ steps.labels.outputs.instance_flavor }}
         FLOATING_IP_UUID: ${{ steps.ip_create.outputs.floating_ip_uuid }}
+        ISSUE_NUMBER: ${{ inputs.issue_number }}
+        GH_TOKEN: ${{ inputs.token }}
+        GH_REPO: ${{ github.repository }}
+        DEFAULT_SESSION_TIMEOUT_HRS: ${{ inputs.default_session_timeout_hrs }}
 
     - name: Wait for instance to reach stable state
       id: wait_instance_state

--- a/.github/workflows/create-course-instance.yml
+++ b/.github/workflows/create-course-instance.yml
@@ -319,6 +319,7 @@ jobs:
           instance_name_prefix: ${{ vars.INSTANCE_NAME_PREFIX }}
           volume_name_suffix: ${{ vars.VOLUME_NAME_SUFFIX }}
           volume_size_gb: ${{ vars.VOLUME_SIZE_GB || '100' }}
+          default_session_timeout_hrs: ${{ vars.INSTANCE_SHELVING_TIMEOUT_HRS }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       # Course creates stay one job (acquire + setup back-to-back on the same

--- a/.github/workflows/create-instance-from-workflow.yml
+++ b/.github/workflows/create-instance-from-workflow.yml
@@ -119,6 +119,7 @@ jobs:
           instance_name_prefix: ${{ vars.INSTANCE_NAME_PREFIX }}
           volume_name_suffix: ${{ vars.VOLUME_NAME_PREFIX }}
           volume_size_gb: ${{ vars.VOLUME_SIZE_GB || '100' }}
+          default_session_timeout_hrs: ${{ vars.INSTANCE_SHELVING_TIMEOUT_HRS }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
   # Job B — setup lane (cloud-init wait, volume mount, reboot, email). Runs on the

--- a/.github/workflows/create-instance.yml
+++ b/.github/workflows/create-instance.yml
@@ -264,6 +264,7 @@ jobs:
           instance_name_prefix: ${{ vars.INSTANCE_NAME_PREFIX }}
           volume_name_suffix: ${{ vars.VOLUME_NAME_SUFFIX }}
           volume_size_gb: ${{ vars.VOLUME_SIZE_GB || '100' }}
+          default_session_timeout_hrs: ${{ vars.INSTANCE_SHELVING_TIMEOUT_HRS }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       # Individual creates stay one job (acquire + setup back-to-back on the

--- a/cloud-config
+++ b/cloud-config
@@ -80,12 +80,12 @@ retry git clone \
   "https://github.com/MorphoCloud/exosphere.git" \
   /opt/instance-config-mgt
 
-exosphere_sha="371a188abf480ede688466fbe4a03e34d9a7f784" # morpho-cloud-portal-2026.06-ubuntu24-prep
+exosphere_sha="dadf0b592d3a01164ed1897f54a42a4e4494234e" # morpho-cloud-portal-2026.06-ubuntu24-prep
 (cd /opt/instance-config-mgt && git reset --hard $exosphere_sha)
 
 ansible-playbook \
   -i /opt/instance-config-mgt/ansible/hosts \
-  -e "{\"guac_enabled\":true,\"gui_enabled\":true,\"ansible_python_interpreter\":\"/opt/ansible-venv/bin/python\"}" \
+  -e "{\"guac_enabled\":true,\"gui_enabled\":true,\"session_timeout_hrs\":{session-timeout-hrs},\"ansible_python_interpreter\":\"/opt/ansible-venv/bin/python\"}" \
   /opt/instance-config-mgt/ansible/playbook.yml
 ANSIBLE_RETURN_CODE=$?
 if [ $ANSIBLE_RETURN_CODE -eq 0 ]; then STATUS="complete"; else STATUS="error"; fi


### PR DESCRIPTION
cloud-config passes session_timeout_hrs (sed at create time: the
issue's highest timeout:<N>hrs label, else the repo's
INSTANCE_SHELVING_TIMEOUT_HRS, else 4) and pins exosphere @dadf0b59,
where check-instance-shelve.sh now derives its warning window and
dialog texts from that value. Aligns the in-instance popup with the
flavor-based 2-hour timeouts; with no label/variable everything
behaves exactly as before.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
