### PR TITLE
fix: clear mechanical findings from the review backlog (#228)

### DIFF
--- a/.github/actions/lookup-email/action.yml
+++ b/.github/actions/lookup-email/action.yml
@@ -17,6 +17,8 @@ inputs:
       "Course team slug (mc-…). When set and lookup_url is an Apps Script
       endpoint, uses lookup_course_roster — the roster sheet is resolved
       server-side from the approved course, never named by the caller."
+    required: false
+    default: ""
   api_key:
     description:
       "Optional API key sent as X-Api-Key header. Required when lookup_url

--- a/.github/actions/retrieve-metadata/action.yml
+++ b/.github/actions/retrieve-metadata/action.yml
@@ -52,7 +52,7 @@ runs:
         instance_ip=""
         while (( SECONDS - ip_start < ip_max_wait )); do
           instance_ip=$(
-            openstack server show $INSTANCE_NAME -c addresses -f json | \
+            openstack server show "$INSTANCE_NAME" -c addresses -f json | \
             jq -r '.addresses.auto_allocated_network[1] // empty'
           )
           if [[ -n "$instance_ip" && "$instance_ip" != "null" ]]; then
@@ -70,7 +70,7 @@ runs:
 
         # Get instance password from tags
         instance_pwd=$(
-          openstack server show $INSTANCE_NAME -c tags -f json | \
+          openstack server show "$INSTANCE_NAME" -c tags -f json | \
           jq -r '.tags[] | select(startswith("exoPw")) | sub("^exoPw:"; "")'
         )
 

--- a/.github/actions/send-email/render.py
+++ b/.github/actions/send-email/render.py
@@ -9,6 +9,7 @@ markdown all pass through untouched.
 import json
 import os
 import sys
+import uuid
 from pathlib import Path
 
 t = json.loads(Path(sys.argv[1]).read_text())
@@ -31,10 +32,11 @@ def render(text: str) -> str:
     return text
 
 
+delimiter = f"__RENDER_EOF_{uuid.uuid4().hex}__"
 with Path(os.environ["GITHUB_OUTPUT"]).open("a") as out:
-    out.write("subject<<__RENDER_EOF__\n")
+    out.write(f"subject<<{delimiter}\n")
     out.write(render(t["credentials_subject"]) + "\n")
-    out.write("__RENDER_EOF__\n")
-    out.write("body<<__RENDER_EOF__\n")
+    out.write(f"{delimiter}\n")
+    out.write(f"body<<{delimiter}\n")
     out.write(render(t["credentials_body"]) + "\n")
-    out.write("__RENDER_EOF__\n")
+    out.write(f"{delimiter}\n")

--- a/.github/workflows/create-course-instance.yml
+++ b/.github/workflows/create-course-instance.yml
@@ -86,6 +86,9 @@ jobs:
           fi
 
           if [[ -z "$COURSE_TEAM_SLUG" ]]; then
+            gh issue comment "$ISSUE_NUMBER" --body "### Command Results ❌
+
+          This course repo is not fully configured (\`COURSE_TEAM_SLUG\` is unset), so \`/create\` cannot proceed. Please tag @MorphoCloud/morphocloud-admins."
             echo "::error ::COURSE_TEAM_SLUG is not configured for this repo"
             exit 1
           fi

--- a/.github/workflows/guard-issue-close.yml
+++ b/.github/workflows/guard-issue-close.yml
@@ -54,9 +54,12 @@ jobs:
               -f issue_number="$ISSUE_NUMBER" \
               -f command_name=shelve
             STATE="**${INSTANCE_NAME}** is being shelved — allocation usage stops; your data and volume are preserved"
+          elif [[ "$SERVER_STATUS" == "SHELVED" || "$SERVER_STATUS" == "SHELVED_OFFLOADED" ]]; then
+            echo "$INSTANCE_NAME is $SERVER_STATUS — already shelved."
+            STATE="**${INSTANCE_NAME}** remains shelved; your data and volume are preserved"
           elif [[ -n "$SERVER_STATUS" ]]; then
             echo "$INSTANCE_NAME is $SERVER_STATUS — nothing to shelve."
-            STATE="**${INSTANCE_NAME}** remains shelved; your data and volume are preserved"
+            STATE="**${INSTANCE_NAME}** (status: ${SERVER_STATUS}); your data and volume are preserved"
           else
             STATE="the **${VOLUME_NAME}** data volume is preserved"
           fi

--- a/.github/workflows/request-labeler.yml
+++ b/.github/workflows/request-labeler.yml
@@ -80,8 +80,9 @@ jobs:
             hrs="$(echo "${pair##*=}" | xargs)"
             if [[ "$FLAVOR" == "$f" && "$hrs" =~ ^[1-9][0-9]*$ ]]; then
               echo "Flavor $FLAVOR -> timeout:${hrs}hrs (from MORPHOCLOUD_FLAVOR_TIMEOUT_OVERRIDES)"
-              gh label create "timeout:${hrs}hrs" --color "5319E7" --description "Instance shelves after ${hrs}h uptime" --force >/dev/null 2>&1 || true
-              gh issue edit "$NUMBER" --add-label "timeout:${hrs}hrs"
+              gh label create "timeout:${hrs}hrs" --color "5319E7" --description "Session timeout: ${hrs} hours" --force >/dev/null 2>&1 || true
+              gh issue edit "$NUMBER" --add-label "timeout:${hrs}hrs" \
+                || echo "::warning ::Could not apply timeout:${hrs}hrs to #$NUMBER; instance keeps the default session timeout"
               break
             fi
           done

--- a/.github/workflows/request-labeler.yml
+++ b/.github/workflows/request-labeler.yml
@@ -78,8 +78,9 @@ jobs:
           for pair in "${PAIRS[@]}"; do
             f="$(echo "${pair%%=*}" | xargs)"
             hrs="$(echo "${pair##*=}" | xargs)"
-            if [[ "$FLAVOR" == "$f" && "$hrs" =~ ^[0-9]+$ ]]; then
+            if [[ "$FLAVOR" == "$f" && "$hrs" =~ ^[1-9][0-9]*$ ]]; then
               echo "Flavor $FLAVOR -> timeout:${hrs}hrs (from MORPHOCLOUD_FLAVOR_TIMEOUT_OVERRIDES)"
+              gh label create "timeout:${hrs}hrs" --color "5319E7" --description "Instance shelves after ${hrs}h uptime" --force >/dev/null 2>&1 || true
               gh issue edit "$NUMBER" --add-label "timeout:${hrs}hrs"
               break
             fi


### PR DESCRIPTION
Addresses the actionable items in #228 (the review-backlog sweep). Every finding was **re-verified against current code before fixing** — net result: **7 fixed here, 4 dismissed as noise, 2 held for a design decision.**

## Fixed (7)

| Finding | Sev | File | Change |
| --- | --- | --- | --- |
| #224 | HIGH | `request-labeler.yml` | `gh label create … --force` guard before `--add-label`, so an override hour not declared in `labels.yml` can't fail the step and block instance creation |
| #224 | MED | `request-labeler.yml` | regex `^[0-9]+$` → `^[1-9][0-9]*$` — reject `0`, which would shelve on the next cron tick |
| #213 | MED | `send-email/render.py` | per-run random heredoc delimiter; a rendered line equal to `__RENDER_EOF__` no longer silently truncates the email |
| #214 | MED | `guard-issue-close.yml` | explicit `SHELVED`/`SHELVED_OFFLOADED` branch; other states no longer wrongly told "remains shelved" |
| #204 | MED | `create-course-instance.yml` | comment on the issue before exiting when `COURSE_TEAM_SLUG` is unset (was a failed run with no explanation) |
| #205 | MED | `lookup-email/action.yml` | `course_team_slug` input gets `required: false` + `default: ""`, matching the other optional inputs |
| #227 | MED | `retrieve-metadata/action.yml` | quote `$INSTANCE_NAME` in both `openstack server show` calls |

## Dismissed (4) — verified, not worth a change

- **#214 HIGH (unguarded `gh workflow run`)** — false positive: Actions runs `run:` blocks under `bash -eo pipefail`, so a failed dispatch aborts the step before the "is being shelved" comment is posted.
- **#205 MED (`"secret":""` always sent)** — speculative: in the only path that sends it, `GAS_SECRET` is required and non-empty, so an empty secret fails auth regardless.
- **#225 MED (`|| true` on timeout read)** — the `|| true` is an intentional graceful fallback to the default; a warning adds little.
- **#204 MED (exosphere commit check uses `GITHUB_TOKEN` / hides stderr)** — `MorphoCloud/exosphere` is public, so `GITHUB_TOKEN` reads it fine; low value.

## Held (2) — need a design decision (left open in #228)

- **#205 HIGH** — empty `COURSE_TEAM_SLUG` → individual-email routing in `control-instance`. Needs a decision on how to detect a course-repo context for a fail-fast guard.
- **#223 MED** — setup-failed servers stuck at `status:building`. Reviewer flagged it *may be intentional*; needs an error-state design.

Refs #228.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
