### PR TITLE
fix: Raise unshelve/FIP wait budgets for JS2 slowness

### DIFF
--- a/.github/actions/control-instance/action.yml
+++ b/.github/actions/control-instance/action.yml
@@ -352,7 +352,7 @@ runs:
         if has_ip; then
           echo "Floating IP already associated."
         else
-          max_wait=120
+          max_wait=300   # JS2 floating-IP association can lag under load
           interval=10
           start=$SECONDS
           associated=false
@@ -422,9 +422,9 @@ runs:
       run: |
         source ~/venv/bin/activate
 
-        max_wait_time=300  # Maximum wait time in seconds (300s -> 5mins)
+        max_wait_time=600  # 10 min — unshelve from offloaded can be slow under JS2 load
         if [[ "$EXPECTED_STATUS" == "SHELVED_OFFLOADED" ]]; then
-          max_wait_time=600  # Maximum wait time in seconds (600s -> 10mins)
+          max_wait_time=900  # 15 min — offload to object storage is the slowest transition
         fi
 
         echo "Polling '$INSTANCE_NAME' status [max_wait_time=${max_wait_time}s]"

--- a/.github/actions/retrieve-metadata/action.yml
+++ b/.github/actions/retrieve-metadata/action.yml
@@ -46,7 +46,7 @@ runs:
         # floating IP, so a single read can see 'null' (or only the fixed IP)
         # and a credential email would fail spuriously. Retry until the
         # floating IP is attached, mirroring the password retry below.
-        ip_max_wait=120
+        ip_max_wait=300   # JS2 floating-IP reassociation after unshelve can be slow under load
         ip_interval=10
         ip_start=$SECONDS
         instance_ip=""


### PR DESCRIPTION
June 18 saw JS2 floating-IP reassociation and offloaded-unshelve run
slower than our timeouts, producing 'Failed to retrieve metadata' (#110),
unshelve 'maximum wait exceeded' (#117) — no scarcity, transient
platform slowness. Budgets raised so the steps ride it out instead of
erroring + forcing a manual retry:
- retrieve-metadata floating-IP read: 120s -> 300s
- control-instance floating-IP association: 120s -> 300s
- control-instance status poll: 300s -> 600s (ACTIVE/unshelve),
  600s -> 900s (SHELVED_OFFLOADED)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
